### PR TITLE
Standard Payload: Exclude "excluded_classes" not only for ground truth fields but also for model prediction fields

### DIFF
--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -200,9 +200,14 @@ class PayloadProcessor:
         detections = {}
         for field_name in self.models + [self.gt_field]:
             field = self.get_field_name(sequence_view, field_name, unwinding=True)
+            det_values = sequence_view.filter_labels(
+                        field,
+                        ~F("label").is_in(self.excluded_classes),
+                        only_matches=False,
+                    ).values(f"{field}.detections")
             detections[field_name] = [
                 d if d is not None else []
-                for d in sequence_view.values(f"{field}.detections")
+                for d in det_values
             ]
         return Sequence(resolution=self.get_resolution(sequence_view), **detections)
 


### PR DESCRIPTION
## What?
 
The standard payload now excludes the labels given in `excluded_classes` (see code below) not only in the ground truth fields but also in the model prediction fields.
https://github.com/SEA-AI/seametrics/blob/ef8aa77b3a72257ff062bed90c58fae6b9e5fc21/seametrics/payload/processor.py#L27
 
## Why?
 
We want to compute the bounding box metrics for our panoptic segmentation models, to be able to compare their performance against our object detection models. We do this using the bounding boxes that are defined by the predicted masks. Currently, the excluded classes are only excluded for the ground truth, since, so far, object detection models predicted only instance bounding boxes and no removal there was needed. However, we do not want to include background classes from the segmentation prediction in this metric calculation. Thus, we now need to exclude the excluded classes from the model prediction field as well.
 
## How?
 
To implement this change, only one filtering stage was added to the code: https://github.com/SEA-AI/seametrics/blob/ef8aa77b3a72257ff062bed90c58fae6b9e5fc21/seametrics/payload/processor.py#L203-L207
 
## Testing
 
The already implemented pytests were again executed.
![image](https://github.com/SEA-AI/seametrics/assets/64644326/4702c850-439b-4c1b-a7ec-5618500f8cb8)
![image](https://github.com/SEA-AI/seametrics/assets/64644326/03711a13-cb64-4cd7-97f3-0c631293af81)
![image](https://github.com/SEA-AI/seametrics/assets/64644326/5cce4555-198c-463d-aca6-eb25f386e994)

Additionally, the behavior was tested with a sequence from the "SAILING_PANOPTIC_DATASET_QA" dataset. The sequence has 
* eight ground truth detections with labels `'WATER', 'SKY', 'LAND', 'SAILING_BOAT_WITH_CLOSED_SAILS', 'SAILING_BOAT_WITH_OPEN_SAILS', 'FAR_AWAY_OBJECT', 'FAR_AWAY_OBJECT', 'FAR_AWAY_OBJECT'`, and
* four model detections with labels `['SAILING_BOAT_WITH_CLOSED_SAILS', 'SKY', 'WATER', 'LAND']`.

#### Default
By default, a number of classes are excluded: https://github.com/SEA-AI/seametrics/blob/ef8aa77b3a72257ff062bed90c58fae6b9e5fc21/seametrics/constants.py#L1-L13. From the test code below we can observe that the default excluded classes indeed are also excluded from the model predictions.

Test code:
```python
payload = PayloadProcessor(dataset_name="SAILING_PANOPTIC_DATASET_QA", sequence_list=["Trip_17_Seq_1"], gt_field="ground_truth_det", models=["maskformer-10k_20ep"])
d = payload.compute_payload()
preds = d.to_dict()["sequences"]["Trip_17_Seq_1"]["maskformer-10k_20ep"][0]
print("Length of detections in payload: ", len(preds))
print([det.label for det in preds])
````
Output:
```
Length of detections in payload:  3
['SAILING_BOAT_WITH_CLOSED_SAILS', 'SKY', 'LAND']
```
#### No excluded classes
To test it with no excluded classes at all, the following code is run:

Test code:
```python
payload = PayloadProcessor(dataset_name="SAILING_PANOPTIC_DATASET_QA", sequence_list=["Trip_17_Seq_1"], excluded_classes=[""], gt_field="ground_truth_det", models=["maskformer-10k_20ep"])
d = payload.compute_payload()
preds = d.to_dict()["sequences"]["Trip_17_Seq_1"]["maskformer-10k_20ep"][0]
print("Length of detections in payload: ", len(preds))
print([det.label for det in preds])
```
Output:
```
Length of detections in payload:  4
['SAILING_BOAT_WITH_CLOSED_SAILS', 'SKY', 'WATER', 'LAND']
```

#### Custom excluded classes
We overwrite the default excluded classes and only exclude `WATER` and `SKY` and observe the output of the ground truth field, as well of the model prediction. The behaviour is as intended and corresponding detections are removed from both fields.
**Model prediction:**

Test code:
```python
payload = PayloadProcessor(dataset_name="SAILING_PANOPTIC_DATASET_QA", sequence_list=["Trip_17_Seq_1"], excluded_classes=["WATER", "SKY"], gt_field="ground_truth_det", models=["maskformer-10k_20ep"])
d = payload.compute_payload()
preds = d.to_dict()["sequences"]["Trip_17_Seq_1"]["maskformer-10k_20ep"][0]
print("Length of detections in payload: ", len(preds))
print([det.label for det in preds])
```
Output:
```
Length of detections in payload:  2
['SAILING_BOAT_WITH_CLOSED_SAILS', 'LAND']
```

**Ground truth:**

Test code:
```python
preds = d.to_dict()["sequences"]["Trip_17_Seq_1"]["ground_truth_det"][0]
print("Length of detections in ground truth payload: ", len(preds))
print([det.label for det in preds])
```
Output:
```
Length of detections in ground truth payload:  2
['SAILING_BOAT_WITH_CLOSED_SAILS', 'LAND']
```