### PR TITLE
Add a github action file to run tests automatically

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies and run some pytests
+name: Python application
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - uses: actions/cache@v3
+      id: cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.*') }}
+        restore-keys: | 
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
## What?
 
Added a github action file to set up a simple workflow that allows us to run pytest automatically. 
 
## Why?
 
Tests are cool, but we tend to forget about them. By automatically triggering a test on every push and pull request to the develop branch, we can find bugs as soon as possible. 
 
## How?
 
Just used a template and change a few parameters. (https://vilisimo.com/blog/setting-up-pytest-with-github-actions/)

## Testing

Testing the same actions.yaml on a test repository 
<img width="895" alt="image" src="https://github.com/SEA-AI/seametrics/assets/29953180/2707e6b3-d560-4d6d-8987-ce7bd2e168fc">

