### PR TITLE
update to venv caching strategy

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,23 +16,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: 🛎️ Checkout
+      uses: actions/checkout@v4
       with:
-        python-version: "3.10"
-    - uses: actions/cache@v3
-      id: cache
+          ref: ${{ github.head_ref }}
+    - name: 🐍 Set up Python 3.8
+      id: setup-python
+      uses: actions/setup-python@v5
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.*') }}
-        restore-keys: | 
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
+        python-version: "3.8"
+    - name: 📦 Cache venv
+      id: cache-venv
+      uses: actions/cache@v4
+      with:
+        path: ./.venv/
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+            ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
+    - name: 🦾 Install dependencies
+      shell: bash
       run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m venv ./.venv
+          source ./.venv/bin/activate
+          python -m pip install --upgrade pip wheel
+          pip install ".[dev, inference]" --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Install repo project # We do this since the install deps step can be skipped
+      shell: bash
+      run: |
+        source ./.venv/bin/activate
+        python -m pip install -U -e .
     - name: Test with pytest
       run: |
-        pytest
+        source ./.venv/bin/activate
+        python -m pip install -U -e .
+        python -m pytest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,6 +40,7 @@ jobs:
           source ./.venv/bin/activate
           python -m pip install --upgrade pip wheel
           pip install ".[test, fiftyone]" --extra-index-url https://download.pytorch.org/whl/cpu
+      if: steps.cache-venv.outputs.cache-hit != 'true'
     - name: Install repo project # We do this since the install deps step can be skipped
       shell: bash
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,11 +41,11 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install ".[test, fiftyone]" --extra-index-url https://download.pytorch.org/whl/cpu
       if: steps.cache-venv.outputs.cache-hit != 'true'
-    - name: Install repo project # We do this since the install deps step can be skipped
-      shell: bash
-      run: |
-        source ./.venv/bin/activate
-        python -m pip install -U -e .
+    #- name: 🕵️ Test virtual environment activation
+    #  shell: bash
+    #  run: |
+    #    source ./.venv/bin/activate
+    #    python -m pip install -U -e .
     - name: Test with pytest
       run: |
         source ./.venv/bin/activate

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,7 +39,7 @@ jobs:
           python -m venv ./.venv
           source ./.venv/bin/activate
           python -m pip install --upgrade pip wheel
-          pip install ".[test]" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install ".[test, fiftyone]" --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Install repo project # We do this since the install deps step can be skipped
       shell: bash
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,7 +39,7 @@ jobs:
           python -m venv ./.venv
           source ./.venv/bin/activate
           python -m pip install --upgrade pip wheel
-          pip install ".[dev, inference]" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install ".[test]" --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Install repo project # We do this since the install deps step can be skipped
       shell: bash
       run: |


### PR DESCRIPTION
## What?
 
Instead of just caching the pip cache folder, now the whole venv is cached.
 
## Why?
 
This improved the execution time when the workflow is triggered
 
## How?
 If the cache key was not found, the dependencies are installed as usual using a virtual environment. Otherwise, if the cache key was found the virtual environment would be activated and the content of the .venv folder will be loaded from the cache. 

## Testing
 
It was tested by manually trigger the workflow again.
<img width="873" alt="not-using-cache" src="https://github.com/SEA-AI/seametrics/assets/29953180/c7a04338-432e-40e3-8470-9688d3990fcc">
<img width="873" alt="using-cache" src="https://github.com/SEA-AI/seametrics/assets/29953180/56cef774-b452-4af4-89d2-577438678da4">

Note: Using this strategy, the size of the cache will be larger that using method provided by github but the execution time is much faster. Also keep in mind that the venv must be activated in every step. For more references see:https://medium-parser.vercel.app/?url=https://mckornfield.medium.com/caching-python-installs-in-github-actions-8309e12a15e6