### PR TITLE
Added unit test to cover frame id change

### DIFF
--- a/tests/payload/test_processor.py
+++ b/tests/payload/test_processor.py
@@ -136,3 +136,38 @@ def test_accidental_tuple_as_models(mock_fiftyone, mock_compute_payload):
             models=models,
             tracking_mode=False,
         )
+
+def test_payload_initialization_with_frame_ids(mock_fiftyone, mock_compute_payload):
+    """
+    Test that start_frame_id and end_frame_id are set correctly.
+    """
+    processor = PayloadProcessor(
+        dataset_name="valid_dataset",
+        gt_field="ground_truth_det",
+        models=["model1"],
+        tracking_mode=False,
+        start_frame_id=5,
+        end_frame_id=10,
+    )
+    assert processor.start_frame_id == 5
+    assert processor.end_frame_id == 11  
+
+    processor = PayloadProcessor(
+        dataset_name="valid_dataset",
+        gt_field="ground_truth_det",
+        models=["model1"],
+        tracking_mode=False,
+        start_frame_id=2,
+        end_frame_id=None,
+    )
+    assert processor.start_frame_id == 2
+    assert processor.end_frame_id is None
+
+    processor = PayloadProcessor(
+        dataset_name="valid_dataset",
+        gt_field="ground_truth_det",
+        models=["model1"],
+        tracking_mode=False,
+    )
+    assert processor.start_frame_id is None
+    assert processor.end_frame_id is None


### PR DESCRIPTION
## What?
 
Added unit test to cover frame id change.
 
## Why?

Some sequences have a really large number of frames which caused the scripts on the ml-ops to crash due to RAM limitations. To solve this, we added the feature to define explicitly break the sequence into smaller batches and process them. This unit test asserts if the start and end frame ids are being correctly set on the `PayloadProcessor` class

## How?

This test function tested 3 cases:
- We define the start and end frame ids when we instantiate the class.
- We only define the start id 
- We define neither of them
 
## Testing
 
I ran the `pytest` command with this added test and everything passed.