### PR TITLE
sequence_list and tag intersection fix

### DIFF
--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -173,10 +173,11 @@ class PayloadProcessor:
         if self.tags:
             self.dataset = self.dataset.match_tags(self.tags, all=True)
 
-        if not self.sequence_list or len(self.sequence_list) == 0:
-            self.sequence_list = self.dataset.distinct("sequence")
-            logger.info(f"Using all sequences in dataset: {self.sequence_list}")
-            
+        if self.sequence_list:
+            self.dataset = self.dataset.match(F("sequence").is_in(self.sequence_list))
+
+        self.sequence_list = self.dataset.distinct("sequence")
+
         logger.info(f"Using slice: {relevant_slices}")
 
         return self.process_sequences()


### PR DESCRIPTION
## What?
 
There was a "bug" when both the sequence_list and tags arguments of the PayloadProcessor were used at the same time.

If any sequence inside the sequence_list was not part of the dataset view after the match_tags query was done. it would raise the following error while running the process_sequences method:

![Screenshot from 2024-10-29 15-31-18](https://github.com/user-attachments/assets/f6f378c7-1397-492d-9634-db413251c530)
![Screenshot from 2024-10-29 15-31-08](https://github.com/user-attachments/assets/612362b0-33f3-4c44-a200-78ad6619d3be)

We fixed that error by making another query to the dataset view to only include the sequences in the sequence_list and subsequently extracting the sequences present in the the final dataset views after all the queries

## Why?
 
We needed to fix this so we could use both arguments at the same time
 
## How?
 
before:
´´´python

        if self.tags:
            self.dataset = self.dataset.match_tags(self.tags, all=True)

        if not self.sequence_list or len(self.sequence_list) == 0:
            self.sequence_list = self.dataset.distinct("sequence")
            logger.info(f"Using all sequences in dataset: {self.sequence_list}")
´´´
now:

´´´python

        if self.tags:
            self.dataset = self.dataset.match_tags(self.tags, all=True)

        if self.sequence_list:
            self.dataset = self.dataset.match(F("sequence").is_in(self.sequence_list))

        self.sequence_list = self.dataset.distinct("sequence")
´´´
## Testing
 
After the fix we get a new size for the sequences being processed which are the intersection of all the queries

![Screenshot from 2024-10-29 15-25-09](https://github.com/user-attachments/assets/de87ddf6-cbe9-4a2b-b1b6-57558bfd1d63)
