### PR TITLE
PrecisionRecallF1 fix concatenating empty lists

### DIFF
--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,4 @@
+{
+    "sonarCloudOrganization": "sea-ai",
+    "projectKey": "SEA-AI_seametrics"
+}

--- a/seametrics/detection/np/pr_rec_f1.py
+++ b/seametrics/detection/np/pr_rec_f1.py
@@ -569,9 +569,10 @@ class PrecisionRecallF1Support:
 
     def _get_classes(self) -> List:
         """Return a list of unique classes found in ground truth and detection data."""
-        all_labels = np.concatenate(self.detection_labels + self.groundtruth_labels)
-        unique_classes = np.unique(all_labels)
-        return unique_classes.tolist()
+        if len(self.detection_labels) > 0 or len(self.groundtruth_labels) > 0:
+            all_labels = np.concatenate(self.detection_labels + self.groundtruth_labels)
+            return np.unique(all_labels).tolist()
+        return []
 
     def _get_coco_format(
         self,

--- a/tests/detection/test_pr_rec_f1.py
+++ b/tests/detection/test_pr_rec_f1.py
@@ -1,22 +1,8 @@
-from typing import Type
-import pytest
 import numpy as np
-from seametrics.detection.np.pr_rec_f1 import PrecisionRecallF1Support as PRF1Np
+from seametrics.detection import PrecisionRecallF1Support
 
-backends = [PRF1Np]
-
-# Try importing the torchmetrics-based backend
-try:
-    from seametrics.detection.tm.pr_rec_f1 import PrecisionRecallF1Support as PRF1Tm
-
-    backends.append(PRF1Tm)
-except ImportError:
-    print("TorchMetrics not installed, skipping corresponding tests.")
-
-
-@pytest.mark.parametrize("MetricClass", backends)
-def test_no_images_with_default_args(MetricClass: Type[PRF1Np]):
-    metric = MetricClass()
+def test_no_images_with_default_args():
+    metric = PrecisionRecallF1Support()
     preds = []
     target = []
     metric.update(preds, target)
@@ -37,9 +23,8 @@ def test_no_images_with_default_args(MetricClass: Type[PRF1Np]):
         assert val["nImgs"] == 0
 
 
-@pytest.mark.parametrize("MetricClass", backends)
-def test_no_preds_and_target_with_default_args(MetricClass: Type[PRF1Np]):
-    metric = MetricClass()
+def test_no_preds_and_target_with_default_args():
+    metric = PrecisionRecallF1Support()
     preds = [
         dict(
             boxes=np.array([]),
@@ -71,9 +56,8 @@ def test_no_preds_and_target_with_default_args(MetricClass: Type[PRF1Np]):
         assert val["nImgs"] == 1
 
 
-@pytest.mark.parametrize("MetricClass", backends)
-def test_empty_gt_false_pred_with_default_args(MetricClass: Type[PRF1Np]):
-    metric = MetricClass()
+def test_empty_gt_false_pred_with_default_args():
+    metric = PrecisionRecallF1Support()
     preds = [
         dict(
             boxes=np.array([[258.0, 41.0, 606.0, 285.0]]),
@@ -105,9 +89,8 @@ def test_empty_gt_false_pred_with_default_args(MetricClass: Type[PRF1Np]):
         assert val["nImgs"] == 1
 
 
-@pytest.mark.parametrize("MetricClass", backends)
-def test_empty_pred_missed_gt_with_default_args(MetricClass: Type[PRF1Np]):
-    metric = MetricClass()
+def test_empty_pred_missed_gt_with_default_args():
+    metric = PrecisionRecallF1Support()
     preds = [
         dict(
             boxes=np.array([]),

--- a/tests/detection/test_pr_rec_f1.py
+++ b/tests/detection/test_pr_rec_f1.py
@@ -1,8 +1,45 @@
+from typing import Type
+import pytest
 import numpy as np
-from seametrics.detection import PrecisionRecallF1Support
+from seametrics.detection.np.pr_rec_f1 import PrecisionRecallF1Support as PRF1Np
 
-def test_empty_input_with_default_args():
-    metric = PrecisionRecallF1Support()
+backends = [PRF1Np]
+
+# Try importing the torchmetrics-based backend
+try:
+    from seametrics.detection.tm.pr_rec_f1 import PrecisionRecallF1Support as PRF1Tm
+
+    backends.append(PRF1Tm)
+except ImportError:
+    print("TorchMetrics not installed, skipping corresponding tests.")
+
+
+@pytest.mark.parametrize("MetricClass", backends)
+def test_no_images_with_default_args(MetricClass: Type[PRF1Np]):
+    metric = MetricClass()
+    preds = []
+    target = []
+    metric.update(preds, target)
+    results = metric.compute()
+    for key, val in results["metrics"].items():
+        assert key == "all"
+        assert val["iouThr"] == "0.50"
+        assert val["maxDets"] == 100
+        assert val["tp"] == 0
+        assert val["fp"] == 0
+        assert val["fn"] == 0
+        assert val["duplicates"] == 0
+        assert val["precision"] == -1
+        assert val["recall"] == -1
+        assert val["f1"] == -1
+        assert val["support"] == 0
+        assert val["fpi"] == 0
+        assert val["nImgs"] == 0
+
+
+@pytest.mark.parametrize("MetricClass", backends)
+def test_no_preds_and_target_with_default_args(MetricClass: Type[PRF1Np]):
+    metric = MetricClass()
     preds = [
         dict(
             boxes=np.array([]),
@@ -18,23 +55,25 @@ def test_empty_input_with_default_args():
     ]
     metric.update(preds, target)
     results = metric.compute()
-    for key, val in results['metrics'].items():
-        assert key == 'all'
-        assert val['iouThr'] == '0.50'
-        assert val['maxDets'] == 100
-        assert val['tp'] == 0
-        assert val['fp'] == 0
-        assert val['fn'] == 0
-        assert val['duplicates'] == 0
-        assert val['precision'] == -1
-        assert val['recall'] == -1
-        assert val['f1'] == -1
-        assert val['support'] == 0
-        assert val['fpi'] == 0
-        assert val['nImgs'] == 1
+    for key, val in results["metrics"].items():
+        assert key == "all"
+        assert val["iouThr"] == "0.50"
+        assert val["maxDets"] == 100
+        assert val["tp"] == 0
+        assert val["fp"] == 0
+        assert val["fn"] == 0
+        assert val["duplicates"] == 0
+        assert val["precision"] == -1
+        assert val["recall"] == -1
+        assert val["f1"] == -1
+        assert val["support"] == 0
+        assert val["fpi"] == 0
+        assert val["nImgs"] == 1
 
-def test_empty_gt_false_pred_with_default_args():
-    metric = PrecisionRecallF1Support()
+
+@pytest.mark.parametrize("MetricClass", backends)
+def test_empty_gt_false_pred_with_default_args(MetricClass: Type[PRF1Np]):
+    metric = MetricClass()
     preds = [
         dict(
             boxes=np.array([[258.0, 41.0, 606.0, 285.0]]),
@@ -50,23 +89,25 @@ def test_empty_gt_false_pred_with_default_args():
     ]
     metric.update(preds, target)
     results = metric.compute()
-    for key, val in results['metrics'].items():
-        assert key == 'all'
-        assert val['iouThr'] == '0.50'
-        assert val['maxDets'] == 100
-        assert val['tp'] == 0
-        assert val['fp'] == 1
-        assert val['fn'] == 0
-        assert val['duplicates'] == 0
-        assert val['precision'] == 0
-        assert val['recall'] == -1
-        assert val['f1'] == -1
-        assert val['support'] == 0
-        assert val['fpi'] == 1
-        assert val['nImgs'] == 1
+    for key, val in results["metrics"].items():
+        assert key == "all"
+        assert val["iouThr"] == "0.50"
+        assert val["maxDets"] == 100
+        assert val["tp"] == 0
+        assert val["fp"] == 1
+        assert val["fn"] == 0
+        assert val["duplicates"] == 0
+        assert val["precision"] == 0
+        assert val["recall"] == -1
+        assert val["f1"] == -1
+        assert val["support"] == 0
+        assert val["fpi"] == 1
+        assert val["nImgs"] == 1
 
-def test_empty_pred_missed_gt_with_default_args():
-    metric = PrecisionRecallF1Support()
+
+@pytest.mark.parametrize("MetricClass", backends)
+def test_empty_pred_missed_gt_with_default_args(MetricClass: Type[PRF1Np]):
+    metric = MetricClass()
     preds = [
         dict(
             boxes=np.array([]),
@@ -82,18 +123,17 @@ def test_empty_pred_missed_gt_with_default_args():
     ]
     metric.update(preds, target)
     results = metric.compute()
-    for key, val in results['metrics'].items():
-        assert key == 'all'
-        assert val['iouThr'] == '0.50'
-        assert val['maxDets'] == 100
-        assert val['tp'] == 0
-        assert val['fp'] == 0
-        assert val['fn'] == 1
-        assert val['duplicates'] == 0
-        assert val['precision'] == -1
-        assert val['recall'] == 0
-        assert val['f1'] == -1
-        assert val['support'] == 1
-        assert val['fpi'] == 0
-        assert val['nImgs'] == 1
-        
+    for key, val in results["metrics"].items():
+        assert key == "all"
+        assert val["iouThr"] == "0.50"
+        assert val["maxDets"] == 100
+        assert val["tp"] == 0
+        assert val["fp"] == 0
+        assert val["fn"] == 1
+        assert val["duplicates"] == 0
+        assert val["precision"] == -1
+        assert val["recall"] == 0
+        assert val["f1"] == -1
+        assert val["support"] == 1
+        assert val["fpi"] == 0
+        assert val["nImgs"] == 1


### PR DESCRIPTION
## What?
 
PrecisionRecallF1 is not more robust to cases where there are no images to analyse at all. Specific case which may arise due to how we build the input from a fiftyone video.
 
## Why?
 
The metrics computation was throwing an error.
 
## How?
 
We check if lists are empty before attempting to concatenate them.
 
## Testing
 
Added unit test where `nImgs == 0`
