### PR TITLE
CV-215: remove deprecated mux field

### DIFF
--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -192,7 +192,7 @@ class PayloadProcessor:
         Raises:
             ValueError: If there is no matching data slice for the data type.
         """
-        thermal_slices = {"thermal_wide", "thermal_right", "thermal_left", "thermal_stitched"}
+        thermal_slices = {"thermal_wide", "thermal_narrow", "thermal_right", "thermal_left", "thermal_stitched"}
         rgb_slices = {"rgb", "rgb_wide", "rgb_narrow"}
 
         existing_slices = set(self.dataset.group_slices)
@@ -273,22 +273,25 @@ class PayloadProcessor:
 
         detections = {}
 
-        if self.tracking_mode:
-            mux_values = [m if m is not None else [] for m in sequence_view.values("frames[].mux")][self.start_frame_id:self.end_frame_id]
-        
         for field_name in self.models + [self.gt_field]:
-            det_values = sequence_view.filter_labels(
+
+            filter_view = sequence_view.filter_labels(
                 self.get_field_name(sequence_view, field_name),
                 ~F("label").is_in(self.excluded_classes),
                 only_matches=False,
-            ).values(
+            )
+            
+            det_values = filter_view.values(
                 f"{self.get_field_name(sequence_view, field_name, unwinding=True)}.detections"
             )[self.start_frame_id:self.end_frame_id]
 
-            if self.tracking_mode:
-                detections[field_name] = [d if d is not None else [] for (d,m) in zip(det_values,mux_values) if self.models[0] in m]
+            keyframe_values = filter_view.values(f"{self.get_field_name(sequence_view, field_name, unwinding=True)}.keyframe")[self.start_frame_id:self.end_frame_id]
+
+            if self.tracking_mode and field_name != self.gt_field:
+                detections[field_name] = [d if d is not None and k else [] for d, k in zip(det_values, keyframe_values)]
             else:
                 detections[field_name] = [d if d is not None else [] for d in det_values]
+
         
         return Sequence(resolution=self.get_resolution(sequence_view), **detections)
 

--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -285,9 +285,8 @@ class PayloadProcessor:
                 f"{self.get_field_name(sequence_view, field_name, unwinding=True)}.detections"
             )[self.start_frame_id:self.end_frame_id]
 
-            keyframe_values = filter_view.values(f"{self.get_field_name(sequence_view, field_name, unwinding=True)}.keyframe")[self.start_frame_id:self.end_frame_id]
-
-            if self.tracking_mode and field_name != self.gt_field:
+            if self.tracking_mode:
+                keyframe_values = filter_view.values(f"{self.get_field_name(sequence_view, self.models[0], unwinding=True)}.keyframe")[self.start_frame_id:self.end_frame_id]
                 detections[field_name] = [d if d is not None and k else [] for d, k in zip(det_values, keyframe_values)]
             else:
                 detections[field_name] = [d if d is not None else [] for d in det_values]


### PR DESCRIPTION
## What?
 
Remove the deprecated `mux` field in tracker mode and handle it using the `keyframe` attribute of frames instead.
 
## Why?
 
To ensure that `det-metrics` works correctly in tracking mode again.
 
## How?

Instead of checking `mux` values, the `keyframe` values (a boolean list indicating if a frame is a keyframe) are now used.
Detections are considered only when the frame is a keyframe; otherwise, an empty list is provided. 

> ℹ️ **Only keyframes are analyzed. For non-keyframes, both the ground truth detections and the model detection list remain empty.**

### Code Changes 👩‍💻

```python
def process_sequence(
        self,
        sequence: str,
    ) -> Sequence:
        """
        Retrieves the sequence data from the dataset view.

        Args:
            sequence (str): The name of the sequence.

        Returns:
            Sequence: The sequence data.
        """
        sequence_view = self.dataset.match(F("sequence") == sequence).filter_labels(
            self.get_field_name(self.dataset, self.gt_field),
            ~F("label").is_in(self.excluded_classes),
            only_matches=False,
        )

        detections = {}

        for field_name in self.models + [self.gt_field]:

            filter_view = sequence_view.filter_labels(
                self.get_field_name(sequence_view, field_name),
                ~F("label").is_in(self.excluded_classes),
                only_matches=False,
            )
            
            det_values = filter_view.values(
                f"{self.get_field_name(sequence_view, field_name, unwinding=True)}.detections"
            )[self.start_frame_id:self.end_frame_id]

            if self.tracking_mode:
                keyframe_values = filter_view.values(f"{self.get_field_name(sequence_view, self.models[0], unwinding=True)}.keyframe")[self.start_frame_id:self.end_frame_id]
                detections[field_name] = [d if d is not None and k else [] for d, k in zip(det_values, keyframe_values)]
            else:
                detections[field_name] = [d if d is not None else [] for d in det_values]
```

### NOTE 🚨
`thermal_narrow` was added to the set of thermal slices in the `get_datatype_slices` method because I dont see a reason to exclude this slice.

### Example Usage 🤝
```python
area_ranges_tuples = [
    ("all", [0, 1e5**2]),
    ("small", [0**2, 6**2]),
    ("medium", [6**2, 12**2]),
    ("large", [12**2, 1e5**2]),
]

# Configure your dataset and model details
processor = PayloadProcessor(
    dataset_name="SENTRY_VIDEOS_DATASET_QA",
    gt_field="annotations_sf_idfuse",
    models=["ahoy-IR-b2_tv_tools"],
    tracking_mode=True,
    sequence_list= sequences,
    data_type="thermal",
    slices = ['thermal_wide'],
    excluded_classes=['BRIDGE', 'HARBOUR', 'WATERTRACK', 'SHORELINE', 'SUN_REFLECTION', 'UNSUPERVISED', 'WATER', 'TRASH', 'OBJECT_REFLECTION', 'HORIZON', 'ALGAE', 'AERIAL_VEHICLE', 'GROWLER', 'DRIFT_ICE', 'ICEBERG']
)

# Evaluate using SEA-AI/det-metrics
module = evaluate.load(
    path="SEA-AI/det-metrics",
    iou_threshold=[0.00001],
    area_ranges_tuples=area_ranges_tuples,
    payload=processor.payload,
)

results = module.compute()
```


## Backout plan 💡

Go back one commit 🔙



## Testing 🧪
`det-metrics` computed for 79 sequences:
![image](https://github.com/user-attachments/assets/f7653723-98dd-48d7-992b-b7c27976e65e)


 

