### PR TITLE
CV-192 renamig the uf metrics

### DIFF
--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -89,11 +89,11 @@ def calculate(
         else:
             summary[key] = float(summary[key][0])
 
-    summary["num_gt_ids"] = unique_gt_ids
+    summary["unique_obj_count"] = unique_gt_ids
 
     for th in recognition_thresholds:
         recognized = recognition(tr_ratios, th)
-        summary[f"recognized_{th}"] = int(recognized)
+        summary[f"mostly_tracked_count_{th}"] = int(recognized)
 
     return summary
 
@@ -296,8 +296,9 @@ def realize_metrics(metrics_dict, recognition_thresholds):
     )
 
     for th in recognition_thresholds:
-        metrics_dict[f"recognition_{th}"] = (
-            metrics_dict[f"recognized_{th}"] / metrics_dict["num_gt_ids"]
+        metrics_dict[f"mostly_tracked_score_{th}"] = (
+            metrics_dict[f"mostly_tracked_count_{th}"]
+            / metrics_dict["unique_obj_count"]
         )
 
     return metrics_dict

--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -8,7 +8,7 @@ def recognition(track_ratios, th=0.5):
     return track_ratios[track_ratios >= th].count()
 
 
-def num_gt_ids(df):
+def unique_obj_count(df):
     """Number of unique gt ids."""
     return df.full["OId"].dropna().unique().shape[0]
 
@@ -78,7 +78,7 @@ def calculate(
 
     df = events_to_df_map(acc.events)
     tr_ratios = track_ratios(df, obj_frequencies(df))
-    unique_gt_ids = num_gt_ids(df)
+    unique_gt_ids = unique_obj_count(df)
 
     namemap = {"num_misses": "fn", "num_false_positives": "fp", "num_detections": "tp"}
 

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -10,10 +10,10 @@ from seametrics.user_friendly.utils import (
     build_metrics_template,
     calculate,
     calculate_from_payload,
-    num_gt_ids,
     realize_metrics,
     recognition,
     sum_dicts,
+    unique_obj_count,
 )
 
 
@@ -67,17 +67,17 @@ def test_calculate():
     assert result["fp"] == 0.0, f"Expected fp to be 0.0, got {result['fp']}"
     assert result["fn"] == 0.0, f"Expected fn to be 0.0, got {result['fn']}"
     assert (
-        result["num_gt_ids"] == 2
-    ), f"Expected num_gt_ids to be 2, got {result['num_gt_ids']}"
+        result["unique_obj_count"] == 2
+    ), f"Expected unique_obj_count to be 2, got {result['unique_obj_count']}"
     assert (
-        result["recognized_0.3"] == 2
-    ), f"Expected recognized_0.3 to be 2, got {result['recognized_0.3']}"
+        result["mostly_tracked_count_0.3"] == 2
+    ), f"Expected mostly_tracked_count_0.3 to be 2, got {result['mostly_tracked_count_0.3']}"
     assert (
-        result["recognized_0.5"] == 2
-    ), f"Expected recognized_0.5 to be 2, got {result['recognized_0.5']}"
+        result["mostly_tracked_count_0.5"] == 2
+    ), f"Expected mostly_tracked_count_0.5 to be 2, got {result['mostly_tracked_count_0.5']}"
     assert (
-        result["recognized_0.8"] == 2
-    ), f"Expected recognized_0.8 to be 2, got {result['recognized_0.8']}"
+        result["mostly_tracked_count_0.8"] == 2
+    ), f"Expected mostly_tracked_count_0.8 to be 2, got {result['mostly_tracked_count_0.8']}"
 
 
 def test_calculate_empty_inputs_with_exceptions():
@@ -201,7 +201,7 @@ def test_calculate_single_data_point():
     assert result["tp"] == 1, "Expected 1 TP for a matching single data point"
     assert result["fp"] == 0, "No FP expected for a matching single data point"
     assert result["fn"] == 0, "No FN expected for a matching single data point"
-    assert result["num_gt_ids"] == 1, "Expected 1 unique GT ID"
+    assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
     # Non-matching case
     predictions = [[1, 1, 0.5, 0.5, 0.2, 0.2, 0.9]]
@@ -211,7 +211,7 @@ def test_calculate_single_data_point():
     assert result["tp"] == 0, "No TP expected for non-matching data points"
     assert result["fp"] == 1, "Expected 1 FP for non-matching data points"
     assert result["fn"] == 1, "Expected 1 FN for non-matching data points"
-    assert result["num_gt_ids"] == 1, "Expected 1 unique GT ID"
+    assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
 
 def test_calculate_conflicting_ids():
@@ -231,7 +231,7 @@ def test_calculate_conflicting_ids():
     assert result["tp"] == 1, "Only one TP should be counted for duplicate IDs"
     assert result["fp"] == 1, "One FP expected due to duplicate ID"
     assert result["fn"] == 0, "No FN expected as the reference is matched"
-    assert result["num_gt_ids"] == 1, "Expected 1 unique GT ID"
+    assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
 
 def test_calculate_mismatched_frames():
@@ -249,7 +249,7 @@ def test_calculate_mismatched_frames():
     assert result["tp"] == 0, "No TP expected for mismatched frames"
     assert result["fp"] == 1, "All predictions should be FP for mismatched frames"
     assert result["fn"] == 1, "All references should be FN for mismatched frames"
-    assert result["num_gt_ids"] == 1, "Expected 1 unique GT ID"
+    assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
 
 def test_calculate_empty_predictions_or_references():
@@ -469,19 +469,19 @@ def test_realize_metrics():
     1. Typical case with valid metrics.
     2. Edge case with zero TP, FP, FN.
     3. Zero FP but non-zero TP.
-    4. Large num_gt_ids with zero recognized.
+    4. Large unique_obj_count with zero recognized.
     """
     metrics_dict = {
         "tp": 10,
         "fp": 5,
         "fn": 3,
-        "num_gt_ids": 8,
-        "recognized_0.3": 7,
-        "recognized_0.5": 6,
-        "recognized_0.8": 4,
+        "unique_obj_count": 8,
+        "mostly_tracked_count_0.3": 7,
+        "mostly_tracked_count_0.5": 6,
+        "mostly_tracked_count_0.8": 4,
     }
-    recognition_thresholds = [0.3, 0.5, 0.8]
-    result = realize_metrics(metrics_dict, recognition_thresholds)
+    mostly_tracked_score_thresholds = [0.3, 0.5, 0.8]
+    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
 
     assert result["precision"] == 10 / (
         10 + 5
@@ -494,27 +494,27 @@ def test_realize_metrics():
         / (result["precision"] + result["recall"] + 1e-6)
     ), f"Expected f1, got {result['f1']}"
     assert (
-        result["recognition_0.3"] == 7 / 8
-    ), f"Expected recognition_0.3, got {result['recognition_0.3']}"
+        result["mostly_tracked_score_0.3"] == 7 / 8
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["recognition_0.5"] == 6 / 8
-    ), f"Expected recognition_0.5, got {result['recognition_0.5']}"
+        result["mostly_tracked_score_0.5"] == 6 / 8
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
     assert (
-        result["recognition_0.8"] == 4 / 8
-    ), f"Expected recognition_0.8, got {result['recognition_0.8']}"
+        result["mostly_tracked_score_0.8"] == 4 / 8
+    ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
 
     # Test 2: Edge case with zero TP, FP, FN
     metrics_dict = {
         "tp": 0,
         "fp": 0,
         "fn": 0,
-        "num_gt_ids": 1,
-        "recognized_0.3": 0,
-        "recognized_0.5": 0,
-        "recognized_0.8": 0,
+        "unique_obj_count": 1,
+        "mostly_tracked_count_0.3": 0,
+        "mostly_tracked_count_0.5": 0,
+        "mostly_tracked_count_0.8": 0,
     }
-    recognition_thresholds = [0.3, 0.5, 0.8]
-    result = realize_metrics(metrics_dict, recognition_thresholds)
+    mostly_tracked_score_thresholds = [0.3, 0.5, 0.8]
+    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
 
     assert np.isnan(
         result["precision"]
@@ -522,26 +522,26 @@ def test_realize_metrics():
     assert np.isnan(result["recall"]), f"Expected recall NaN, got {result['recall']}"
     assert np.isnan(result["f1"]), f"Expected f1 NaN, got {result['f1']}"
     assert (
-        result["recognition_0.3"] == 0
-    ), f"Expected recognition_0.3, got {result['recognition_0.3']}"
+        result["mostly_tracked_score_0.3"] == 0
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["recognition_0.5"] == 0
-    ), f"Expected recognition_0.5, got {result['recognition_0.5']}"
+        result["mostly_tracked_score_0.5"] == 0
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
     assert (
-        result["recognition_0.8"] == 0
-    ), f"Expected recognition_0.8, got {result['recognition_0.8']}"
+        result["mostly_tracked_score_0.8"] == 0
+    ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
 
     # Test 3: Zero FP but non-zero TP
     metrics_dict = {
         "tp": 5,
         "fp": 0,
         "fn": 2,
-        "num_gt_ids": 10,
-        "recognized_0.3": 3,
-        "recognized_0.5": 1,
+        "unique_obj_count": 10,
+        "mostly_tracked_count_0.3": 3,
+        "mostly_tracked_count_0.5": 1,
     }
-    recognition_thresholds = [0.3, 0.5]
-    result = realize_metrics(metrics_dict, recognition_thresholds)
+    mostly_tracked_score_thresholds = [0.3, 0.5]
+    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
 
     assert result["precision"] == 5 / (
         5 + 0
@@ -554,23 +554,23 @@ def test_realize_metrics():
         / (result["precision"] + result["recall"] + 1e-6)
     ), f"Expected f1, got {result['f1']}"
     assert (
-        result["recognition_0.3"] == 3 / 10
-    ), f"Expected recognition_0.3, got {result['recognition_0.3']}"
+        result["mostly_tracked_score_0.3"] == 3 / 10
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["recognition_0.5"] == 1 / 10
-    ), f"Expected recognition_0.5, got {result['recognition_0.5']}"
+        result["mostly_tracked_score_0.5"] == 1 / 10
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
 
-    # Test 4: Large num_gt_ids with zero recognized
+    # Test 4: Large unique_obj_count with zero recognized
     metrics_dict = {
         "tp": 0,
         "fp": 0,
         "fn": 5,
-        "num_gt_ids": 1000,
-        "recognized_0.3": 0,
-        "recognized_0.5": 0,
+        "unique_obj_count": 1000,
+        "mostly_tracked_count_0.3": 0,
+        "mostly_tracked_count_0.5": 0,
     }
-    recognition_thresholds = [0.3, 0.5]
-    result = realize_metrics(metrics_dict, recognition_thresholds)
+    mostly_tracked_score_thresholds = [0.3, 0.5]
+    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
 
     assert np.isnan(
         result["precision"]
@@ -578,18 +578,18 @@ def test_realize_metrics():
     assert result["recall"] == 0, f"Expected recall 0, got {result['recall']}"
     assert np.isnan(result["f1"]), f"Expected f1 NaN, got {result['f1']}"
     assert (
-        result["recognition_0.3"] == 0
-    ), f"Expected recognition_0.3, got {result['recognition_0.3']}"
+        result["mostly_tracked_score_0.3"] == 0
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["recognition_0.5"] == 0
-    ), f"Expected recognition_0.5, got {result['recognition_0.5']}"
+        result["mostly_tracked_score_0.5"] == 0
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
 
 
-def test_num_gt_ids():
+def test_unique_obj_count():
     """
-    Tests the num_gt_ids function.
+    Tests the unique_obj_count function.
 
-    The num_gt_ids function takes a MOTChallenge events DataFrame and returns the number of unique ground truth IDs in the DataFrame.
+    The unique_obj_count function takes a MOTChallenge events DataFrame and returns the number of unique ground truth IDs in the DataFrame.
 
     The tests cover the following cases:
     1. Typical case with multiple unique IDs
@@ -599,7 +599,7 @@ def test_num_gt_ids():
     5. Same GT ID across all frames
     6. Overlapping and non-overlapping GT IDs
 
-    Each test case runs the num_gt_ids function on a DataFrame created from a MOTChallenge events file and verifies that the output matches the expected number of unique ground truth IDs.
+    Each test case runs the unique_obj_count function on a DataFrame created from a MOTChallenge events file and verifies that the output matches the expected number of unique ground truth IDs.
 
     """
 
@@ -621,7 +621,7 @@ def test_num_gt_ids():
             )
 
         df = mm.metrics.events_to_df_map(acc.events)
-        unique_gt_ids = num_gt_ids(df)
+        unique_gt_ids = unique_obj_count(df)
         assert (
             unique_gt_ids == expected_unique_gt_ids
         ), f"{test_case_name} failed: Expected {expected_unique_gt_ids}, got {unique_gt_ids}"
@@ -738,7 +738,7 @@ def test_calculate_from_payload():
     truth detection and two model detections. The second frame has one ground truth detection and
     one model detection.
 
-    The function is called with max_iou=0.5 and recognition_thresholds=[0.3, 0.5, 0.8]. The test
+    The function is called with max_iou=0.5 and mostly_tracked_score_thresholds=[0.3, 0.5, 0.8]. The test
     asserts that the output contains the correct values for false positives, false negatives,
     true positives, precision, recall, F1 score, recognition at different thresholds, and the
     number of ground truth IDs. The test also asserts that these values are correct for both the
@@ -801,13 +801,13 @@ def test_calculate_from_payload():
 
     payload = create_test_payload()
     max_iou = 0.5
-    recognition_thresholds = [0.3, 0.5, 0.8]
+    mostly_tracked_score_thresholds = [0.3, 0.5, 0.8]
     debug = False
 
     output = calculate_from_payload(
         payload=payload,
         max_iou=max_iou,
-        recognition_thresholds=recognition_thresholds,
+        mostly_tracked_score_thresholds=mostly_tracked_score_thresholds,
         debug=debug,
     )
 
@@ -815,7 +815,9 @@ def test_calculate_from_payload():
     assert global_metrics["fp"] == 1.0, "False positives mismatch"
     assert global_metrics["fn"] == 0.0, "False negatives mismatch"
     assert global_metrics["tp"] == 2.0, "True positives mismatch"
-    assert global_metrics["num_gt_ids"] == 1, "Number of ground truth IDs mismatch"
+    assert (
+        global_metrics["unique_obj_count"] == 1
+    ), "Number of ground truth IDs mismatch"
     assert math.isclose(
         global_metrics["precision"], 0.6666666666666666, rel_tol=1e-9
     ), "Precision mismatch"
@@ -823,18 +825,32 @@ def test_calculate_from_payload():
     assert math.isclose(
         global_metrics["f1"], 0.7999995200002881, rel_tol=1e-9
     ), "F1 score mismatch"
-    assert global_metrics["recognition_0.3"] == 1.0, "Recognition at 0.3 mismatch"
-    assert global_metrics["recognition_0.5"] == 1.0, "Recognition at 0.5 mismatch"
-    assert global_metrics["recognition_0.8"] == 1.0, "Recognition at 0.8 mismatch"
-    assert global_metrics["recognized_0.3"] == 1, "Recognized count at 0.3 mismatch"
-    assert global_metrics["recognized_0.5"] == 1, "Recognized count at 0.5 mismatch"
-    assert global_metrics["recognized_0.8"] == 1, "Recognized count at 0.8 mismatch"
+    assert (
+        global_metrics["mostly_tracked_score_0.3"] == 1.0
+    ), "Recognition at 0.3 mismatch"
+    assert (
+        global_metrics["mostly_tracked_score_0.5"] == 1.0
+    ), "Recognition at 0.5 mismatch"
+    assert (
+        global_metrics["mostly_tracked_score_0.8"] == 1.0
+    ), "Recognition at 0.8 mismatch"
+    assert (
+        global_metrics["mostly_tracked_count_0.3"] == 1
+    ), "Recognized count at 0.3 mismatch"
+    assert (
+        global_metrics["mostly_tracked_count_0.5"] == 1
+    ), "Recognized count at 0.5 mismatch"
+    assert (
+        global_metrics["mostly_tracked_count_0.8"] == 1
+    ), "Recognized count at 0.8 mismatch"
 
     sequence_metrics = output["per_sequence"]["sequence_a"]["model"]["all"]
     assert sequence_metrics["fp"] == 1.0, "Per-sequence false positives mismatch"
     assert sequence_metrics["fn"] == 0.0, "Per-sequence false negatives mismatch"
     assert sequence_metrics["tp"] == 2.0, "Per-sequence true positives mismatch"
-    assert sequence_metrics["num_gt_ids"] == 1, "Per-sequence ground truth IDs mismatch"
+    assert (
+        sequence_metrics["unique_obj_count"] == 1
+    ), "Per-sequence ground truth IDs mismatch"
     assert math.isclose(
         global_metrics["precision"], 0.6666666666666666, rel_tol=1e-9
     ), "Per-sequence Precision mismatch"
@@ -843,20 +859,20 @@ def test_calculate_from_payload():
         global_metrics["f1"], 0.7999995200002881, rel_tol=1e-9
     ), "Per-sequence F1 score mismatch"
     assert (
-        sequence_metrics["recognition_0.3"] == 1.0
+        sequence_metrics["mostly_tracked_score_0.3"] == 1.0
     ), "Per-sequence recognition at 0.3 mismatch"
     assert (
-        sequence_metrics["recognition_0.5"] == 1.0
+        sequence_metrics["mostly_tracked_score_0.5"] == 1.0
     ), "Per-sequence recognition at 0.5 mismatch"
     assert (
-        sequence_metrics["recognition_0.8"] == 1.0
+        sequence_metrics["mostly_tracked_score_0.8"] == 1.0
     ), "Per-sequence recognition at 0.8 mismatch"
     assert (
-        sequence_metrics["recognized_0.3"] == 1
+        sequence_metrics["mostly_tracked_count_0.3"] == 1
     ), "Per-sequence recognized count at 0.3 mismatch"
     assert (
-        sequence_metrics["recognized_0.5"] == 1
+        sequence_metrics["mostly_tracked_count_0.5"] == 1
     ), "Per-sequence recognized count at 0.5 mismatch"
     assert (
-        sequence_metrics["recognized_0.8"] == 1
+        sequence_metrics["mostly_tracked_count_0.8"] == 1
     ), "Per-sequence recognized count at 0.8 mismatch"

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -480,8 +480,8 @@ def test_realize_metrics():
         "mostly_tracked_count_0.5": 6,
         "mostly_tracked_count_0.8": 4,
     }
-    mostly_tracked_score_thresholds = [0.3, 0.5, 0.8]
-    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
+    recognition_thresholds = [0.3, 0.5, 0.8]
+    result = realize_metrics(metrics_dict, recognition_thresholds)
 
     assert result["precision"] == 10 / (
         10 + 5
@@ -513,8 +513,8 @@ def test_realize_metrics():
         "mostly_tracked_count_0.5": 0,
         "mostly_tracked_count_0.8": 0,
     }
-    mostly_tracked_score_thresholds = [0.3, 0.5, 0.8]
-    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
+    recognition_thresholds = [0.3, 0.5, 0.8]
+    result = realize_metrics(metrics_dict, recognition_thresholds)
 
     assert np.isnan(
         result["precision"]
@@ -540,8 +540,8 @@ def test_realize_metrics():
         "mostly_tracked_count_0.3": 3,
         "mostly_tracked_count_0.5": 1,
     }
-    mostly_tracked_score_thresholds = [0.3, 0.5]
-    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
+    recognition_thresholds = [0.3, 0.5]
+    result = realize_metrics(metrics_dict, recognition_thresholds)
 
     assert result["precision"] == 5 / (
         5 + 0
@@ -569,8 +569,8 @@ def test_realize_metrics():
         "mostly_tracked_count_0.3": 0,
         "mostly_tracked_count_0.5": 0,
     }
-    mostly_tracked_score_thresholds = [0.3, 0.5]
-    result = realize_metrics(metrics_dict, mostly_tracked_score_thresholds)
+    recognition_thresholds = [0.3, 0.5]
+    result = realize_metrics(metrics_dict, recognition_thresholds)
 
     assert np.isnan(
         result["precision"]
@@ -738,7 +738,7 @@ def test_calculate_from_payload():
     truth detection and two model detections. The second frame has one ground truth detection and
     one model detection.
 
-    The function is called with max_iou=0.5 and mostly_tracked_score_thresholds=[0.3, 0.5, 0.8]. The test
+    The function is called with max_iou=0.5 and recognition_thresholds=[0.3, 0.5, 0.8]. The test
     asserts that the output contains the correct values for false positives, false negatives,
     true positives, precision, recall, F1 score, recognition at different thresholds, and the
     number of ground truth IDs. The test also asserts that these values are correct for both the
@@ -801,13 +801,13 @@ def test_calculate_from_payload():
 
     payload = create_test_payload()
     max_iou = 0.5
-    mostly_tracked_score_thresholds = [0.3, 0.5, 0.8]
+    recognition_thresholds = [0.3, 0.5, 0.8]
     debug = False
 
     output = calculate_from_payload(
         payload=payload,
         max_iou=max_iou,
-        mostly_tracked_score_thresholds=mostly_tracked_score_thresholds,
+        recognition_thresholds=recognition_thresholds,
         debug=debug,
     )
 


### PR DESCRIPTION
## What?
 
Renaming some of the user friendly metrics 
 
## Why?
 
Make the metrics more intuitive to understand and remove confusion
 
## How?
 
Renaming `recognized_%` to `mostly_tracked_count_%`,  `recognition_%` to `mostly_tracked_score_%` and `num_gt_ids` to `unique_obj_count`

## Backout plan

simply renaming
 
## Testing

![image](https://github.com/user-attachments/assets/cea0ff2f-7d09-4369-9854-f894e33cee80)
