### PR TITLE
CV-237 Effortless Metrics fo-upload-function

### DIFF
--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -138,13 +138,12 @@ def fo_upload(
             )
             continue
 
-        dataset.add_sample_field("polymetrics", fo.DictField)
-
         for sequence_name, sequence_metrics in per_sequence.items():
             sequence_view = dataset.match(fo.ViewField("sequence") == sequence_name)
 
             if len(sequence_view) == 0:
-                logging.warning(f"Sequence {sequence_name} not found. Skipping.")
+                logging.warning(f"Sequence {sequence_name} not found.")
+                continue
 
             # Add metric to each sample
             for sample in sequence_view:

--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -82,13 +82,12 @@ def fo_upload(
     dataset_name: str,
     metrics: Dict[str, Dict],
     metric_name: str,
-    description: Dict[str, Any],
-    field_prefix: str = "metrics",
+    description: Dict[str, Any] = None,
 ) -> None:
     """
     Upload detection metrics to a FiftyOne dataset. A new field is created
-    for each model in the dataset. The field name is "{field_prefix}_{model_name}",
-    and queryable ex: "{field_prefix}_{model_name}.{metric_name}.{area_range}.{'f1/precision/recall...'}".
+    for each model in the dataset. The field name is "polymetrics",
+    and queryable ex: "{polymetrics}.{model_name}.{metric_name}.{area_range}.{'f1/precision/recall...'}".
     Note: this function is compatible with the Polymetrics tool.
 
     The metrics field should be a dictionary of the following form:
@@ -116,10 +115,8 @@ def fo_upload(
             A dictionary containing metrics for multiple models and their sequences.
         metric_name (str):
             The base name for the metrics field.
-        description (dict):
-            A dictionary containing the run configuration of the metric.
-        field_prefix (str, optional):
-            The field_prefix for the metrics field. Defaults to "metrics".
+        description (dict, optional):
+            A dictionary of the metrics run configuration. This parameter is optional and defaults to `None` if not provided.
 
     Returns:
         None
@@ -141,7 +138,7 @@ def fo_upload(
             )
             continue
 
-        dataset.add_sample_field(f"{field_prefix}_{model_name}", fo.DictField)
+        dataset.add_sample_field("polymetrics", fo.DictField)
 
         for sequence_name, sequence_metrics in per_sequence.items():
             sequence_view = dataset.match(fo.ViewField("sequence") == sequence_name)
@@ -151,9 +148,10 @@ def fo_upload(
 
             # Add metric to each sample
             for sample in sequence_view:
-                sample[f"{field_prefix}_{model_name}"] = {}
-                sample[f"{field_prefix}_{model_name}"][metric_name] = sequence_metrics
-                sample[f"{field_prefix}_{model_name}"][metric_name][
+                sample["polymetrics"] = {}
+                sample["polymetrics"][model_name] = {}
+                sample["polymetrics"][model_name][metric_name] = sequence_metrics
+                sample["polymetrics"][model_name][metric_name][
                     "description"
                 ] = description
                 sample.save()

--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -88,10 +88,10 @@ def fo_upload(
     """
     Upload detection metrics to a FiftyOne dataset. A new field is created
     for each model in the dataset. The field name is "{field_prefix}_{model_name}",
-    and queryable ex: "{field_prefix}_{model_name}.{metric_name}.{area_range}{'f1'}".
+    and queryable ex: "{field_prefix}_{model_name}.{metric_name}.{area_range}.{'f1/precision/recall...'}".
     Note: this function is compatible with the Polymetrics tool.
 
-    The metrics should be of the following form:
+    The metrics field should be a dictionary of the following form:
     {
         "model_name": {
             "overall": {

--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -1,6 +1,9 @@
 import logging
+from typing import Any, Dict, List, Literal
+
+import fiftyone as fo
 from deprecated import deprecated
-from typing import List, Dict, Literal
+
 from seametrics.payload.processor import PayloadProcessor
 
 
@@ -73,3 +76,84 @@ def fo_to_payload(
         data_type=data_type,
         excluded_classes=excluded_classes,
     ).payload
+
+
+def fo_upload(
+    dataset_name: str,
+    metrics: Dict[str, Dict],
+    metric_name: str,
+    description: Dict[str, Any],
+    field_prefix: str = "metrics",
+) -> None:
+    """
+    Upload detection metrics to a FiftyOne dataset. A new field is created
+    for each model in the dataset. The field name is "{field_prefix}_{model_name}",
+    and queryable ex: "{field_prefix}_{model_name}.{metric_name}.{area_range}{'f1'}".
+    Note: this function is compatible with the Polymetrics tool.
+
+    The metrics should be of the following form:
+    {
+        "model_name": {
+            "overall": {
+            "all": {"tp": ..., "fp": ..., "fn": ..., "f1": ...},
+            ...  # more area ranges
+            },
+            "per_sequence": {
+            "sequence_name": {
+                "all": {...},
+                ...  # more area ranges
+            },
+            ...  # more sequences
+            }
+        },
+        ...  # more models
+    }
+
+    Args:
+        dataset_name (str):
+            The FiftyOne dataset view to update.
+        metrics (dict):
+            A dictionary containing metrics for multiple models and their sequences.
+        metric_name (str):
+            The base name for the metrics field.
+        description (dict):
+            A dictionary containing the run configuration of the metric.
+        field_prefix (str, optional):
+            The field_prefix for the metrics field. Defaults to "metrics".
+
+    Returns:
+        None
+    """
+    # Load the dataset
+    dataset = fo.load_dataset(dataset_name)
+
+    if not metrics:
+        logging.warning("metrics is empty. Skipping.")
+        return
+
+    for model_name, model_data in metrics.items():
+
+        per_sequence = model_data.get("per_sequence", {})
+
+        if not per_sequence:
+            logging.warning(
+                f"No per_sequence data found for model {model_name}. Skipping."
+            )
+            continue
+
+        dataset.add_sample_field(f"{field_prefix}_{model_name}", fo.DictField)
+
+        for sequence_name, sequence_metrics in per_sequence.items():
+            sequence_view = dataset.match(fo.ViewField("sequence") == sequence_name)
+
+            if len(sequence_view) == 0:
+                logging.warning(f"Sequence {sequence_name} not found. Skipping.")
+
+            # Add metric to each sample
+            for sample in sequence_view:
+                sample[f"{field_prefix}_{model_name}"] = {}
+                sample[f"{field_prefix}_{model_name}"][metric_name] = sequence_metrics
+                sample[f"{field_prefix}_{model_name}"][metric_name][
+                    "description"
+                ] = description
+                sample.save()


### PR DESCRIPTION
## What?
 
Allow the Polymetrics tool to upload metrics into FiftyOne in a queryable format

## Why?
 
For easier analysis and debugging within FiftyOne.
 
## How?
 
Included a new function `fo_upload()` in `seametrics.fo_utils.utils` which create a new field named `polymetrics` that can be accessible like `polymetrics.{field_name}.{metric_name}.{area_range}.f1/precision/recall...`, the function can be used in this way:

```python
from seametrics.fo_utils.utils import fo_upload

metrics  =  {
    "ahoy-IR": {
        "overall": {
            "all": {
                "tp": 42,
                ...
            }
        },
        "per_sequence": {
            "Sentry_2022_09_Portugal": {
                "all": {
                    "tp": 15,
                    ...
                }
            }, ...
        },
    }
}

dataset_name = "my_dataset"
metric_name = "SEA-AI/ref-metrics"
description = {"evaluate": {}, "payload": {}, "enabled": True}
fo_upload(dataset_name, metrics, metric_name, description)
```

## Backout plan
 
not needed.
 
## Testing
 
Running the upload on a local db with a dummy input data and displaying the values:

```python
from seametrics.fo_utils.utils import fo_upload
from pprint import pprint

metrics = {
        "ahoy-IR": {
            "overall": {
                "all": {
                    "tp": 42,
                    "fp": 8,
                    "fn": 3,
                    "f1": 0.85,
                    "recall": 0.93,
                    "precision": 0.84,
                }
            },
            "per_sequence": {
                "Sentry_2022_09_Portugal_2022_09_16_17_32_33": {
                    "all": {
                        "tp": 15,
                        "fp": 4,
                        "fn": 2,
                        "f1": 0.78,
                        "recall": 0.88,
                        "precision": 0.79,
                    }
                },
                "Sentry_2024_09_Cascais_Fixed_2024_09_07_16_27_17": {
                    "all": {
                        "tp": 10,
                        "fp": 3,
                        "fn": 1,
                        "f1": 0.81,
                        "recall": 0.91,
                        "precision": 0.82,
                    }
                },
                "Sentry_2024_09_Cascais_Fixed_2024_09_07_16_28_19": {
                    "all": {
                        "tp": 17,
                        "fp": 5,
                        "fn": 2,
                        "f1": 0.83,
                        "recall": 0.89,
                        "precision": 0.85,
                    }
                },
            },
        }
    }

dataset_name = "Sentry_recordings_TEST"
dataset = fo.load_dataset(dataset_name)
metric_name = "SEA-AI/ref-metrics"
description = {"evaluate": {}, "payload": {}, "enabled": True}
fo_upload(dataset_name, metrics, metric_name, description)

# sorting based on the f1 value in an ascending way and printing the f1 of the first sequence
sorted_view = dataset.sort_by("polymetrics.ahoy-IR.SEA-AI/ref-metrics.all.f1")
print(f"F1 of the first sequence in an ascending order is {sorted_view.first()['sequence']}  =  {sorted_view.first()['polymetrics']['ahoy-IR']['SEA-AI/ref-metrics']['all']['f1']}")

# sorting based on the f1 value in an descending way and printing the f1 of the first sequence
sorted_view = dataset.sort_by(
    "polymetrics.ahoy-IR.SEA-AI/ref-metrics.all.f1", reverse=True
)
print(f"F1 of the first sequence in a descending order is {sorted_view.first()['sequence']} f1 =  {sorted_view.first()['polymetrics']['ahoy-IR']['SEA-AI/ref-metrics']['all']['f1']}")


print(f"Sum of F1 for the three uploaded sequences: {sorted_view.sum('polymetrics.ahoy-IR.SEA-AI/ref-metrics.all.f1')}")

print(f"Description: {sorted_view.first()['polymetrics']['ahoy-IR']['SEA-AI/ref-metrics']['description']} ")
```

![image](https://github.com/user-attachments/assets/ea93ca04-7e92-405b-852d-cc0ccbbf0703)


