### PR TITLE
Cv 247 effortless metrics results adapt uf metrics 

### DIFF
--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -73,7 +73,7 @@ def calculate(
 
     mh = mm.metrics.create()
     summary = mh.compute(
-        acc, metrics=["num_misses", "num_false_positives", "num_detections"]
+        acc, metrics=["num_misses", "num_detections"]
     ).to_dict()
 
     df = events_to_df_map(acc.events)
@@ -98,26 +98,79 @@ def calculate(
     return summary
 
 
-def build_metrics_template(models, filters):
+def build_metrics_template(filter):
+    """builds the metrics template"""
     metrics_dict = {}
-    for model in models:
-        metrics_dict[model] = {}
-        metrics_dict[model]["all"] = {}
-        for filter, filter_ranges in filters.items():
-            metrics_dict[model][filter] = {}
-            for filter_range in filter_ranges:
-                filter_range_name = filter_range[0]
-                metrics_dict[model][filter][filter_range_name] = {}
+    for filter_range in filter:
+        filter_range_name = filter_range[0]
+        metrics_dict[filter_range_name] = {}
     return metrics_dict
 
+def get_formated_references(frames, filter):
+    """formats the references for the calculate_from_payload function, based on the filter and its ranges"""
+    
+    filter_name = filter["name"]
+    filter_ranges = filter["ranges"]
+    formated_references = {}
 
-def calculate_from_payload(
-    payload: dict,
-    max_iou: float = 0.5,
-    filters={},
-    recognition_thresholds=[0.3, 0.5, 0.8],
-    debug: bool = False,
-):
+    for filter_range in filter_ranges:
+        filter_range_name = filter_range[0]
+        formated_references[filter_range_name] = []
+
+    for frame_id, frame in enumerate(frames):
+        for detection in frame:
+            index = detection["index"]
+            x, y, w, h = detection["bounding_box"]
+            filter_value = detection[filter_name]
+
+            for filter_range in filter_ranges:
+                filter_range_name, filter_range_limits = (
+                    filter_range[0],
+                    filter_range[1],
+                )
+                if (
+                    filter_value >= filter_range_limits[0]
+                    and filter_value <= filter_range_limits[1]
+                ):
+                    formated_references[filter_range_name].append(
+                        [frame_id + 1, index, x, y, w, h]
+                    )
+
+    return formated_references
+
+def get_formated_predictions(frames):
+    """formats the predictions for the calculate_from_payload function"""
+    formated_predictions = []
+    for frame_id, frame in enumerate(frames):
+        for detection in frame:
+            index = detection["index"]
+            x, y, w, h = detection["bounding_box"]
+            confidence = 1
+            formated_predictions.append(
+                [frame_id + 1, index, x, y, w, h, confidence]
+            )
+
+    return formated_predictions
+
+def calculate_from_payload(payload: dict,
+                        max_iou: float = 0.5, 
+                        filter={"name": "area", 
+                                "ranges": [("all", [0, 1e5**2])]},
+                        recognition_thresholds=[0.3, 0.5, 0.8], 
+                        debug: bool = False):
+    """
+    Filter in the form of:
+    {
+    "name": "area"
+    "ranges": [("all", [0, 1e5**2]), ("small", [0**2, 6**2]), ("medium", [6**2, 12**2]), ("large", [12**2, 1e5**2])]
+    }
+
+    Receives a payload and returns the metrics
+    """
+    
+    filter_name = filter["name"]
+    filter_ranges = filter["ranges"]
+    output = {}
 
     if not isinstance(payload, dict):
         try:
@@ -134,119 +187,61 @@ def calculate_from_payload(
         print("gt_field_name: ", gt_field_name)
         print("models: ", models)
         print("sequence_list: ", sequence_list)
+    
+    for model in models:
 
-    metrics_per_sequence = {}
-    metrics_global = build_metrics_template(models, filters)
+        metrics_overall = build_metrics_template(filter["ranges"])
+        metrics_per_sequence = {}
+        for sequence in sequence_list:
 
-    for sequence in sequence_list:
-        metrics_per_sequence[sequence] = {}
-        frames = payload["sequences"][sequence][gt_field_name]
+            metrics_per_sequence[sequence] = build_metrics_template(filter["ranges"])
 
-        all_formated_references = {"all": []}
-        for filter, filter_ranges in filters.items():
-            all_formated_references[filter] = {}
-            for filter_range in filter_ranges:
-                filter_range_name = filter_range[0]
-                all_formated_references[filter][filter_range_name] = []
+            frames = payload["sequences"][sequence][gt_field_name]
+            formated_references = get_formated_references(frames, filter)
 
-        for frame_id, frame in enumerate(frames):
-            for detection in frame:
-                index = detection["index"]
-                x, y, w, h = detection["bounding_box"]
-                all_formated_references["all"].append([frame_id + 1, index, x, y, w, h])
-
-                for filter, filter_ranges in filters.items():
-                    filter_value = detection[filter]
-                    for filter_range in filter_ranges:
-                        filter_range_name, filter_range_limits = (
-                            filter_range[0],
-                            filter_range[1],
-                        )
-                        if (
-                            filter_value >= filter_range_limits[0]
-                            and filter_value <= filter_range_limits[1]
-                        ):
-                            all_formated_references[filter][filter_range_name].append(
-                                [frame_id + 1, index, x, y, w, h]
-                            )
-
-        metrics_per_sequence[sequence] = build_metrics_template(models, filters)
-
-        for model in models:
             frames = payload["sequences"][sequence][model]
-            formated_predictions = []
-
-            for frame_id, frame in enumerate(frames):
-                for detection in frame:
-                    index = detection["index"]
-                    x, y, w, h = detection["bounding_box"]
-                    confidence = 1
-                    formated_predictions.append(
-                        [frame_id + 1, index, x, y, w, h, confidence]
-                    )
-
-            if debug:
-                print("sequence/model: ", sequence, model)
-                print("formated_predictions: ", formated_predictions)
-                print("formated_references: ", all_formated_references)
+            formated_predictions = get_formated_predictions(frames)
 
             if len(formated_predictions) == 0:
-                metrics_per_sequence[sequence][model] = "Model had no predictions."
-            elif len(all_formated_references["all"]) == 0:
-                metrics_per_sequence[sequence][model] = "No ground truth."
-
+                metrics_per_sequence[sequence] = "Model had no predictions."
             else:
 
-                sequence_metrics = calculate(
-                    formated_predictions,
-                    all_formated_references["all"],
-                    max_iou=max_iou,
-                    recognition_thresholds=recognition_thresholds,
-                )
-                sequence_metrics = realize_metrics(
-                    sequence_metrics, recognition_thresholds
-                )
-                metrics_per_sequence[sequence][model]["all"] = sequence_metrics
+                for filter_range in filter_ranges:
+                    
+                    filter_range_name = filter_range[0]
+                    if len(formated_references[filter_range_name]) == 0:
+                        metrics_per_sequence[sequence][filter_range_name] = "No ground truth."
+                        continue
 
-                metrics_global[model]["all"] = sum_dicts(
-                    metrics_global[model]["all"], sequence_metrics
-                )
-                metrics_global[model]["all"] = realize_metrics(
-                    metrics_global[model]["all"], recognition_thresholds
-                )
+                    sequence_metrics = calculate(
+                        formated_predictions,
+                        formated_references[filter_range_name],
+                        max_iou=max_iou,
+                        recognition_thresholds=recognition_thresholds,
+                    )
 
-                for filter, filter_ranges in filters.items():
+                    metrics_per_sequence[sequence][filter_range_name] = realize_metrics(
+                        sequence_metrics,
+                        recognition_thresholds,
+                    )
 
-                    for filter_range in filter_ranges:
+                    metrics_overall[filter_range_name] = sum_dicts(
+                        metrics_overall[filter_range_name],
+                        metrics_per_sequence[sequence][filter_range_name],
+                    )
 
-                        filter_range_name = filter_range[0]
-                        sequence_metrics = calculate(
-                            formated_predictions,
-                            all_formated_references[filter][filter_range_name],
-                            max_iou=max_iou,
-                            recognition_thresholds=recognition_thresholds,
-                        )
-                        sequence_metrics = realize_metrics(
-                            sequence_metrics, recognition_thresholds
-                        )
-                        metrics_per_sequence[sequence][model][filter][
-                            filter_range_name
-                        ] = sequence_metrics
-
-                        metrics_global[model][filter][filter_range_name] = sum_dicts(
-                            metrics_global[model][filter][filter_range_name],
-                            sequence_metrics,
-                        )
-                        metrics_global[model][filter][filter_range_name] = (
-                            realize_metrics(
-                                metrics_global[model][filter][filter_range_name],
-                                recognition_thresholds,
-                            )
-                        )
-
-    output = {"global": metrics_global, "per_sequence": metrics_per_sequence}
+                    metrics_overall[filter_range_name] = realize_metrics(
+                        metrics_overall[filter_range_name],
+                        recognition_thresholds,
+                    )
+                
+        output[model] = {
+            "per_sequence": metrics_per_sequence,
+            "overall": metrics_overall,
+        }
 
     return output
+            
 
 
 def sum_dicts(dict1, dict2):
@@ -274,26 +269,12 @@ def realize_metrics(metrics_dict, recognition_thresholds):
     calculates metrics based on raw metrics
     """
 
-    if metrics_dict["tp"] + metrics_dict["fp"] > 0:
-        metrics_dict["precision"] = metrics_dict["tp"] / (
-            metrics_dict["tp"] + metrics_dict["fp"]
-        )
-    else:
-        metrics_dict["precision"] = np.nan
-
     if metrics_dict["tp"] + metrics_dict["fn"] > 0:
         metrics_dict["recall"] = metrics_dict["tp"] / (
             metrics_dict["tp"] + metrics_dict["fn"]
         )
     else:
         metrics_dict["recall"] = np.nan
-
-    metrics_dict["f1"] = (
-        2
-        * metrics_dict["precision"]
-        * metrics_dict["recall"]
-        / (metrics_dict["precision"] + metrics_dict["recall"] + 1e-6)
-    )
 
     for th in recognition_thresholds:
         metrics_dict[f"mostly_tracked_score_{th}"] = (

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -60,11 +60,9 @@ def test_calculate():
     result = calculate(predictions, references)
 
     assert "tp" in result
-    assert "fp" in result
     assert "fn" in result
 
     assert result["tp"] == 2.0, f"Expected tp to be 2.0, got {result['tp']}"
-    assert result["fp"] == 0.0, f"Expected fp to be 0.0, got {result['fp']}"
     assert result["fn"] == 0.0, f"Expected fn to be 0.0, got {result['fn']}"
     assert (
         result["unique_obj_count"] == 2
@@ -199,7 +197,6 @@ def test_calculate_single_data_point():
     result = calculate(predictions, references)
 
     assert result["tp"] == 1, "Expected 1 TP for a matching single data point"
-    assert result["fp"] == 0, "No FP expected for a matching single data point"
     assert result["fn"] == 0, "No FN expected for a matching single data point"
     assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
@@ -209,7 +206,6 @@ def test_calculate_single_data_point():
     result = calculate(predictions, references)
 
     assert result["tp"] == 0, "No TP expected for non-matching data points"
-    assert result["fp"] == 1, "Expected 1 FP for non-matching data points"
     assert result["fn"] == 1, "Expected 1 FN for non-matching data points"
     assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
@@ -229,7 +225,6 @@ def test_calculate_conflicting_ids():
     result = calculate(predictions, references)
 
     assert result["tp"] == 1, "Only one TP should be counted for duplicate IDs"
-    assert result["fp"] == 1, "One FP expected due to duplicate ID"
     assert result["fn"] == 0, "No FN expected as the reference is matched"
     assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
@@ -247,7 +242,6 @@ def test_calculate_mismatched_frames():
     result = calculate(predictions, references)
 
     assert result["tp"] == 0, "No TP expected for mismatched frames"
-    assert result["fp"] == 1, "All predictions should be FP for mismatched frames"
     assert result["fn"] == 1, "All references should be FN for mismatched frames"
     assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
@@ -381,83 +375,23 @@ def test_build_metrics_template():
     4. Single model and single filter with no ranges.
     5. Large number of models and filters.
     """
-    models = ["model1", "model2"]
-    filters = {
-        "filter1": [("range1", 1), ("range2", 2)],
-        "filter2": [("range3", 3)],
-    }
+
+    filter_input = {"name": "area", 
+            "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]}
+    
     expected = {
-        "model1": {
             "all": {},
-            "filter1": {
-                "range1": {},
-                "range2": {},
-            },
-            "filter2": {
-                "range3": {},
-            },
-        },
-        "model2": {
-            "all": {},
-            "filter1": {
-                "range1": {},
-                "range2": {},
-            },
-            "filter2": {
-                "range3": {},
-            },
-        },
-    }
-    result = build_metrics_template(models, filters)
+            "small": {}}
+    
+    result = build_metrics_template(filter_input["ranges"])
     assert result == expected, f"Test 1 failed: {result}"
 
-    # Test 2: Empty models list
-    models = []
-    filters = {
-        "filter1": [("range1", 1)],
-    }
+    # Test 2: Empty filter
+    filter_input = {"name": "area",
+            "ranges": []}
     expected = {}
-    result = build_metrics_template(models, filters)
+    result = build_metrics_template(filter_input["ranges"])
     assert result == expected, f"Test 2 failed: {result}"
-
-    # Test 3: Empty filters dictionary
-    models = ["model1"]
-    filters = {}
-    expected = {
-        "model1": {
-            "all": {},
-        },
-    }
-    result = build_metrics_template(models, filters)
-    assert result == expected, f"Test 3 failed: {result}"
-
-    # Test 4: Single model and single filter with no ranges
-    models = ["model1"]
-    filters = {"filter1": []}
-    expected = {
-        "model1": {
-            "all": {},
-            "filter1": {},
-        },
-    }
-    result = build_metrics_template(models, filters)
-    assert result == expected, f"Test 4 failed: {result}"
-
-    # Test 5: Large number of models and filters
-    models = [f"model{i}" for i in range(5)]
-    filters = {f"filter{j}": [(f"range{k}", k) for k in range(3)] for j in range(3)}
-    result = build_metrics_template(models, filters)
-    for model in models:
-        assert model in result, f"Model {model} missing in result"
-        assert "all" in result[model], f"'all' missing for model {model}"
-        for filter_name, filter_ranges in filters.items():
-            assert (
-                filter_name in result[model]
-            ), f"Filter {filter_name} missing for model {model}"
-            for filter_range in filter_ranges:
-                assert (
-                    filter_range[0] in result[model][filter_name]
-                ), f"Range {filter_range[0]} missing for filter {filter_name} in model {model}"
 
 
 def test_realize_metrics():
@@ -473,7 +407,6 @@ def test_realize_metrics():
     """
     metrics_dict = {
         "tp": 10,
-        "fp": 5,
         "fn": 3,
         "unique_obj_count": 8,
         "mostly_tracked_count_0.3": 7,
@@ -483,16 +416,7 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert result["precision"] == 10 / (
-        10 + 5
-    ), f"Expected precision, got {result['precision']}"
     assert result["recall"] == 10 / (10 + 3), f"Expected recall, got {result['recall']}"
-    assert result["f1"] == (
-        2
-        * result["precision"]
-        * result["recall"]
-        / (result["precision"] + result["recall"] + 1e-6)
-    ), f"Expected f1, got {result['f1']}"
     assert (
         result["mostly_tracked_score_0.3"] == 7 / 8
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
@@ -506,7 +430,6 @@ def test_realize_metrics():
     # Test 2: Edge case with zero TP, FP, FN
     metrics_dict = {
         "tp": 0,
-        "fp": 0,
         "fn": 0,
         "unique_obj_count": 1,
         "mostly_tracked_count_0.3": 0,
@@ -516,11 +439,7 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert np.isnan(
-        result["precision"]
-    ), f"Expected precision NaN, got {result['precision']}"
     assert np.isnan(result["recall"]), f"Expected recall NaN, got {result['recall']}"
-    assert np.isnan(result["f1"]), f"Expected f1 NaN, got {result['f1']}"
     assert (
         result["mostly_tracked_score_0.3"] == 0
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
@@ -534,7 +453,6 @@ def test_realize_metrics():
     # Test 3: Zero FP but non-zero TP
     metrics_dict = {
         "tp": 5,
-        "fp": 0,
         "fn": 2,
         "unique_obj_count": 10,
         "mostly_tracked_count_0.3": 3,
@@ -543,16 +461,7 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert result["precision"] == 5 / (
-        5 + 0
-    ), f"Expected precision, got {result['precision']}"
     assert result["recall"] == 5 / (5 + 2), f"Expected recall, got {result['recall']}"
-    assert result["f1"] == (
-        2
-        * result["precision"]
-        * result["recall"]
-        / (result["precision"] + result["recall"] + 1e-6)
-    ), f"Expected f1, got {result['f1']}"
     assert (
         result["mostly_tracked_score_0.3"] == 3 / 10
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
@@ -563,7 +472,6 @@ def test_realize_metrics():
     # Test 4: Large unique_obj_count with zero recognized
     metrics_dict = {
         "tp": 0,
-        "fp": 0,
         "fn": 5,
         "unique_obj_count": 1000,
         "mostly_tracked_count_0.3": 0,
@@ -572,11 +480,7 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert np.isnan(
-        result["precision"]
-    ), f"Expected precision NaN, got {result['precision']}"
     assert result["recall"] == 0, f"Expected recall 0, got {result['recall']}"
-    assert np.isnan(result["f1"]), f"Expected f1 NaN, got {result['f1']}"
     assert (
         result["mostly_tracked_score_0.3"] == 0
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
@@ -762,6 +666,7 @@ def test_calculate_from_payload():
                 "tags": [],
                 "label": "MOTORBOAT",
                 "bounding_box": [0.0, 0.0, 0.015625, 0.009765625],
+                "area": 0.015625*640*0.009765625*512,
                 "mask": None,
                 "confidence": None,
                 "index": 1,
@@ -772,6 +677,7 @@ def test_calculate_from_payload():
                 "tags": [],
                 "label": "SPHERICAL_BUOY",
                 "bounding_box": [0.603125, 0.591796875, 0.0109375, 0.009765625],
+                "area": 0.015625*640*0.009765625*512,
                 "mask": None,
                 "confidence": None,
                 "index": 2,
@@ -806,25 +712,22 @@ def test_calculate_from_payload():
 
     output = calculate_from_payload(
         payload=payload,
+        filter={"name": "area", 
+        "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]},
         max_iou=max_iou,
         recognition_thresholds=recognition_thresholds,
         debug=debug,
     )
 
-    global_metrics = output["global"]["model"]["all"]
-    assert global_metrics["fp"] == 1.0, "False positives mismatch"
+    print(output["model"]["overall"]["small"])
+    print(output["model"]["overall"]["all"])
+    global_metrics = output["model"]["overall"]["all"]
     assert global_metrics["fn"] == 0.0, "False negatives mismatch"
     assert global_metrics["tp"] == 2.0, "True positives mismatch"
     assert (
         global_metrics["unique_obj_count"] == 1
     ), "Number of ground truth IDs mismatch"
-    assert math.isclose(
-        global_metrics["precision"], 0.6666666666666666, rel_tol=1e-9
-    ), "Precision mismatch"
     assert global_metrics["recall"] == 1.0, "Recall mismatch"
-    assert math.isclose(
-        global_metrics["f1"], 0.7999995200002881, rel_tol=1e-9
-    ), "F1 score mismatch"
     assert (
         global_metrics["mostly_tracked_score_0.3"] == 1.0
     ), "Recognition at 0.3 mismatch"
@@ -844,20 +747,13 @@ def test_calculate_from_payload():
         global_metrics["mostly_tracked_count_0.8"] == 1
     ), "Recognized count at 0.8 mismatch"
 
-    sequence_metrics = output["per_sequence"]["sequence_a"]["model"]["all"]
-    assert sequence_metrics["fp"] == 1.0, "Per-sequence false positives mismatch"
+    sequence_metrics = output["model"]["per_sequence"]["sequence_a"]["all"]
     assert sequence_metrics["fn"] == 0.0, "Per-sequence false negatives mismatch"
     assert sequence_metrics["tp"] == 2.0, "Per-sequence true positives mismatch"
     assert (
         sequence_metrics["unique_obj_count"] == 1
     ), "Per-sequence ground truth IDs mismatch"
-    assert math.isclose(
-        global_metrics["precision"], 0.6666666666666666, rel_tol=1e-9
-    ), "Per-sequence Precision mismatch"
     assert sequence_metrics["recall"] == 1.0, "Per-sequence recall mismatch"
-    assert math.isclose(
-        global_metrics["f1"], 0.7999995200002881, rel_tol=1e-9
-    ), "Per-sequence F1 score mismatch"
     assert (
         sequence_metrics["mostly_tracked_score_0.3"] == 1.0
     ), "Per-sequence recognition at 0.3 mismatch"

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -16,6 +16,7 @@ from seametrics.user_friendly.utils import (
     unique_obj_count,
 )
 
+from pprint import pprint
 
 def test_recognition():
     """
@@ -656,17 +657,17 @@ def test_calculate_from_payload():
         Returns:
             Payload: A test Payload object.
         """
-        gt_config = [1, 1]
+        gt_config = [2, 2]
         model_config = [2, 1]
 
-        mock_detections = [
+        mock_detections_a = [
             {
                 "id": "674f2c83d608ab75c380194c",
                 "attributes": {},
                 "tags": [],
                 "label": "MOTORBOAT",
                 "bounding_box": [0.0, 0.0, 0.015625, 0.009765625],
-                "area": 0.015625*640*0.009765625*512,
+                "area": 50,
                 "mask": None,
                 "confidence": None,
                 "index": 1,
@@ -677,7 +678,32 @@ def test_calculate_from_payload():
                 "tags": [],
                 "label": "SPHERICAL_BUOY",
                 "bounding_box": [0.603125, 0.591796875, 0.0109375, 0.009765625],
-                "area": 0.015625*640*0.009765625*512,
+                "area": 30,
+                "mask": None,
+                "confidence": None,
+                "index": 2,
+            },
+        ]
+
+        mock_detections_b = [
+            {
+                "id": "674f2c83d608ab75c380194c",
+                "attributes": {},
+                "tags": [],
+                "label": "MOTORBOAT",
+                "bounding_box": [0.0, 0.0, 0.015625, 0.009765625],
+                "area": 50,
+                "mask": None,
+                "confidence": None,
+                "index": 1,
+            },
+            {
+                "id": "6682d49a4cb7459c1be09c52",
+                "attributes": {},
+                "tags": [],
+                "label": "SPHERICAL_BUOY",
+                "bounding_box": [0.603125, 0.591796875, 0.001765625, 0.009765625],
+                "area": 30,
                 "mask": None,
                 "confidence": None,
                 "index": 2,
@@ -692,14 +718,25 @@ def test_calculate_from_payload():
                 "sequence_a": Sequence(
                     resolution=Resolution(height=512, width=640),
                     ground_truth_det=[
-                        [mock_detections[i] for i in range(detections)]
-                        for detections in gt_config
+                        [mock_detections_a[i] for i in range(n_detections)]
+                        for n_detections in gt_config
                     ],
                     model=[
-                        [mock_detections[i] for i in range(detections)]
-                        for detections in model_config
+                        [mock_detections_a[i] for i in range(n_detections)]
+                        for n_detections in model_config
                     ],
-                )
+                ),
+                "sequence_b": Sequence(
+                    resolution=Resolution(height=512, width=640),
+                    ground_truth_det=[
+                        [mock_detections_b[i] for i in range(n_detections)]
+                        for n_detections in gt_config
+                    ],
+                    model=[
+                        [mock_detections_b[i] for i in range(n_detections)]
+                        for n_detections in model_config
+                    ],
+                ),        
             },
         )
 
@@ -713,21 +750,19 @@ def test_calculate_from_payload():
     output = calculate_from_payload(
         payload=payload,
         filter={"name": "area", 
-        "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]},
+                "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]},
         max_iou=max_iou,
         recognition_thresholds=recognition_thresholds,
         debug=debug,
     )
-
-    print(output["model"]["overall"]["small"])
-    print(output["model"]["overall"]["all"])
+    
     global_metrics = output["model"]["overall"]["all"]
-    assert global_metrics["fn"] == 0.0, "False negatives mismatch"
-    assert global_metrics["tp"] == 2.0, "True positives mismatch"
+    assert global_metrics["fn"] == 2.0, "False negatives mismatch"
+    assert global_metrics["tp"] == 6.0, "True positives mismatch"
     assert (
-        global_metrics["unique_obj_count"] == 1
+        global_metrics["unique_obj_count"] == 4
     ), "Number of ground truth IDs mismatch"
-    assert global_metrics["recall"] == 1.0, "Recall mismatch"
+    assert math.isclose(global_metrics["recall"], 0.75, rel_tol=0.00001), "Recall mismatch"
     assert (
         global_metrics["mostly_tracked_score_0.3"] == 1.0
     ), "Recognition at 0.3 mismatch"
@@ -735,25 +770,25 @@ def test_calculate_from_payload():
         global_metrics["mostly_tracked_score_0.5"] == 1.0
     ), "Recognition at 0.5 mismatch"
     assert (
-        global_metrics["mostly_tracked_score_0.8"] == 1.0
+        global_metrics["mostly_tracked_score_0.8"] == 0.5
     ), "Recognition at 0.8 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0.3"] == 1
+        global_metrics["mostly_tracked_count_0.3"] == 4
     ), "Recognized count at 0.3 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0.5"] == 1
+        global_metrics["mostly_tracked_count_0.5"] == 4
     ), "Recognized count at 0.5 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0.8"] == 1
+        global_metrics["mostly_tracked_count_0.8"] == 2
     ), "Recognized count at 0.8 mismatch"
 
     sequence_metrics = output["model"]["per_sequence"]["sequence_a"]["all"]
-    assert sequence_metrics["fn"] == 0.0, "Per-sequence false negatives mismatch"
-    assert sequence_metrics["tp"] == 2.0, "Per-sequence true positives mismatch"
+    assert sequence_metrics["fn"] == 1.0, "Per-sequence false negatives mismatch"
+    assert sequence_metrics["tp"] == 3.0, "Per-sequence true positives mismatch"
     assert (
-        sequence_metrics["unique_obj_count"] == 1
+        sequence_metrics["unique_obj_count"] == 2
     ), "Per-sequence ground truth IDs mismatch"
-    assert sequence_metrics["recall"] == 1.0, "Per-sequence recall mismatch"
+    assert math.isclose(sequence_metrics["recall"], 0.75, rel_tol=0.00001), "Per-sequence recall mismatch"
     assert (
         sequence_metrics["mostly_tracked_score_0.3"] == 1.0
     ), "Per-sequence recognition at 0.3 mismatch"
@@ -761,13 +796,13 @@ def test_calculate_from_payload():
         sequence_metrics["mostly_tracked_score_0.5"] == 1.0
     ), "Per-sequence recognition at 0.5 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_score_0.8"] == 1.0
+        sequence_metrics["mostly_tracked_score_0.8"] == 0.5
     ), "Per-sequence recognition at 0.8 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0.3"] == 1
+        sequence_metrics["mostly_tracked_count_0.3"] == 2
     ), "Per-sequence recognized count at 0.3 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0.5"] == 1
+        sequence_metrics["mostly_tracked_count_0.5"] == 2
     ), "Per-sequence recognized count at 0.5 mismatch"
     assert (
         sequence_metrics["mostly_tracked_count_0.8"] == 1


### PR DESCRIPTION
## What?

We change the ```calculate_from_payload``` to respect the output format defined by ref-metrics. Changes to the unit tests to reflect these changes had to be made. 

We also remove Precision and F1 from the logs, since these values can be misleading as in this metrics we compare all output detecions agains the ground_truth boxes withing the filtered ranges. This produced artificially low metrics for Precision and in turn F1.

Parallel to this PR, the ```compute_from_payload``` method was also added to the HF space. 

To remove complexity from this metric's package, we decrease the amount of filters from that can be made per run to only one. For example, before we could filter by area, distance, etc... now we can only filter one at a time.

## Why?
 
we need to make the UF metrics compatible with the polymetrics wandb  job by adding a new ```compute_from_payload``` in the HF space. Making the change in seametrics rather then in the HF space avoids unnecessery format conversions in the HF space.
 
## How?
 
The output format is now:

```json
{
    "model": {
        "overall": {
            "all": {
                "tp": 6,
                ...
            }
        },
        "per_sequence": {
            "sequence_a": {
                "all": {
                    "tp": 6,
                ...
                }
            }
        }
    }
}
```

rather then:


```json
{
    "overall": {
        "model": {
            "all": {
                "tp": 6,
                ...
            },
        },
        "per_sequence": {
            "sequence_a": {
                "model": {
                    "all": {
                        "tp": 6,
                        ...
                    },
                }
            }
        }
    }
}
```
## Backout plan

A backout should not be done, since it will make this metrics incompatible with the polymetrics job
 
## Testing
 
```bash
(fiftyone) gil@super:~/git/seametrics/tests/user_friendly$ pytest
...............

---------- coverage: platform linux, python 3.9.19-final-0 -----------
Name                                                            Stmts   Miss  Cover
-----------------------------------------------------------------------------------
/home/gil/git/seametrics/seametrics/__init__.py                     1      0   100%
/home/gil/git/seametrics/seametrics/payload/__init__.py            41     10    76%
/home/gil/git/seametrics/seametrics/user_friendly/__init__.py       0      0   100%
/home/gil/git/seametrics/seametrics/user_friendly/utils.py        135     13    90%
/home/gil/git/seametrics/tests/__init__.py                          0      0   100%
test_uf_utils.py                                                  226      0   100%
-----------------------------------------------------------------------------------
TOTAL  
```


https://wandb.ai/sea-ai/user_friendly_metrics/runs/aiwltlyq?nw=nwuserseaaimlops


(Sorry for the long description, but there were a few things)