### PR TITLE
change empty reference and pred behaviout

### DIFF
--- a/seametrics/user_friendly/uf.py
+++ b/seametrics/user_friendly/uf.py
@@ -1,6 +1,5 @@
 from seametrics.user_friendly.utils import calculate_from_payload
 
-
 class UserFriendlyMetrics:
     """
     Class for computing UserFriendly metrics.

--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -12,14 +12,7 @@ def unique_obj_count(df):
     """Number of unique gt ids."""
     return df.full["OId"].dropna().unique().shape[0]
 
-
-def calculate(
-    predictions,
-    references,
-    max_iou: float = 0.5,
-    recognition_thresholds: list = [0.3, 0.5, 0.8],
-):
-    """Returns the scores"""
+def trasform_inputs(predictions, references):
 
     try:
         np_predictions = np.array(predictions) if predictions else np.empty((0, 7))
@@ -58,12 +51,27 @@ def calculate(
                 "The frame number in the references should be a positive integer"
         )
 
+    return np_predictions, np_references
+
+def calculate(
+    predictions,
+    references,
+    max_iou: float = 0.5,
+    recognition_thresholds: list = [0.3, 0.5, 0.8],
+):
+    """Returns the scores"""
+
+    np_predictions, np_references = trasform_inputs(predictions, references)
+    
     reference_frames = np_references[:, 0].max() if np_references.size > 0 else 0
     prediction_frames = np_predictions[:, 0].max() if np_predictions.size > 0 else 0
+
+    print(len(predictions), len(references))
     
     num_frames = int(max(reference_frames, prediction_frames))
 
     acc = mm.MOTAccumulator(auto_id=True)
+
     for i in range(1, num_frames + 1):
         preds = np_predictions[np_predictions[:, 0] == i, 1:6]
         refs = np_references[np_references[:, 0] == i, 1:6]
@@ -182,6 +190,7 @@ def calculate_from_payload(payload: dict,
             raise ValueError(
                 "The payload should be a dictionary or a compatible object"
             ) from e
+
     gt_field_name = payload["gt_field_name"]
     models = payload["models"]
     sequence_list = payload["sequence_list"]
@@ -198,12 +207,15 @@ def calculate_from_payload(payload: dict,
         for sequence in sequence_list:
 
             metrics_per_sequence[sequence] = build_metrics_template(filter["ranges"])
-
+            print(payload["sequences"])
             frames = payload["sequences"][sequence][gt_field_name]
             formated_references = get_formated_references(frames, filter)
+            print(formated_references)
+
 
             frames = payload["sequences"][sequence][model]
             formated_predictions = get_formated_predictions(frames)
+            print(formated_predictions)
 
             for filter_range in filter_ranges:
                 

--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -22,43 +22,46 @@ def calculate(
     """Returns the scores"""
 
     try:
-        np_predictions = np.array(predictions)
+        np_predictions = np.array(predictions) if predictions else np.empty((0, 7))
     except:
         raise ValueError(
             "The predictions should be a list of np.arrays in the format [frame number, object id, bb_left, bb_top, bb_width, bb_height, confidence]"
         )
 
     try:
-        np_references = np.array(references)
+        np_references = np.array(references) if references else np.empty((0, 6))
     except:
         raise ValueError(
             "The references should be a list of np.arrays in the format [frame number, object id, bb_left, bb_top, bb_width, bb_height]"
         )
 
     if (
-        np_predictions.size == 0
-        or np_predictions.ndim < 2
-        or np_predictions.shape[1] != 7
+        np_predictions.ndim < 2 or np_predictions.shape[1] != 7
     ):
         raise ValueError(
             "The predictions should be a 2D array with 7 columns in the format [frame number, object id, bb_left, bb_top, bb_width, bb_height, confidence]"
         )
 
-    if np_references.size == 0 or np_references.ndim < 2 or np_references.shape[1] != 6:
+    if np_references.ndim < 2 or np_references.shape[1] != 6:
         raise ValueError(
             "The references should be a 2D array with 6 columns in the format [frame number, object id, bb_left, bb_top, bb_width, bb_height]"
         )
 
-    if np_predictions[:, 0].min() <= 0:
-        raise ValueError(
-            "The frame number in the predictions should be a positive integer"
+    if np_predictions.size > 0:
+        if np_predictions[:, 0].min() <= 0 :
+            raise ValueError(
+                "The frame number in the predictions should be a positive integer"
         )
-    if np_references[:, 0].min() <= 0:
-        raise ValueError(
-            "The frame number in the references should be a positive integer"
+    if np_references.size > 0:
+        if np_references[:, 0].min() <= 0:
+            raise ValueError(
+                "The frame number in the references should be a positive integer"
         )
 
-    num_frames = int(max(np_references[:, 0].max(), np_predictions[:, 0].max()))
+    reference_frames = np_references[:, 0].max() if np_references.size > 0 else 0
+    prediction_frames = np_predictions[:, 0].max() if np_predictions.size > 0 else 0
+    
+    num_frames = int(max(reference_frames, prediction_frames))
 
     acc = mm.MOTAccumulator(auto_id=True)
     for i in range(1, num_frames + 1):
@@ -202,38 +205,31 @@ def calculate_from_payload(payload: dict,
             frames = payload["sequences"][sequence][model]
             formated_predictions = get_formated_predictions(frames)
 
-            if len(formated_predictions) == 0:
-                metrics_per_sequence[sequence] = "Model had no predictions."
-            else:
+            for filter_range in filter_ranges:
+                
+                filter_range_name = filter_range[0]
 
-                for filter_range in filter_ranges:
-                    
-                    filter_range_name = filter_range[0]
-                    if len(formated_references[filter_range_name]) == 0:
-                        metrics_per_sequence[sequence][filter_range_name] = "No ground truth."
-                        continue
+                sequence_metrics = calculate(
+                    formated_predictions,
+                    formated_references[filter_range_name],
+                    max_iou=max_iou,
+                    recognition_thresholds=recognition_thresholds,
+                )
 
-                    sequence_metrics = calculate(
-                        formated_predictions,
-                        formated_references[filter_range_name],
-                        max_iou=max_iou,
-                        recognition_thresholds=recognition_thresholds,
-                    )
+                metrics_per_sequence[sequence][filter_range_name] = realize_metrics(
+                    sequence_metrics,
+                    recognition_thresholds,
+                )
 
-                    metrics_per_sequence[sequence][filter_range_name] = realize_metrics(
-                        sequence_metrics,
-                        recognition_thresholds,
-                    )
+                metrics_overall[filter_range_name] = sum_dicts(
+                    metrics_overall[filter_range_name],
+                    metrics_per_sequence[sequence][filter_range_name],
+                )
 
-                    metrics_overall[filter_range_name] = sum_dicts(
-                        metrics_overall[filter_range_name],
-                        metrics_per_sequence[sequence][filter_range_name],
-                    )
-
-                    metrics_overall[filter_range_name] = realize_metrics(
-                        metrics_overall[filter_range_name],
-                        recognition_thresholds,
-                    )
+                metrics_overall[filter_range_name] = realize_metrics(
+                    metrics_overall[filter_range_name],
+                    recognition_thresholds,
+                )
                 
         output[model] = {
             "per_sequence": metrics_per_sequence,
@@ -269,17 +265,14 @@ def realize_metrics(metrics_dict, recognition_thresholds):
     calculates metrics based on raw metrics
     """
 
-    if metrics_dict["tp"] + metrics_dict["fn"] > 0:
-        metrics_dict["recall"] = metrics_dict["tp"] / (
-            metrics_dict["tp"] + metrics_dict["fn"]
-        )
-    else:
-        metrics_dict["recall"] = np.nan
+    metrics_dict["recall"] = metrics_dict["tp"] / (
+        metrics_dict["tp"] + metrics_dict["fn"] + 1e-6
+    )
 
     for th in recognition_thresholds:
         metrics_dict[f"mostly_tracked_score_{th}"] = (
             metrics_dict[f"mostly_tracked_count_{th}"]
-            / metrics_dict["unique_obj_count"]
+            / (metrics_dict["unique_obj_count"]+1e-6)
         )
 
     return metrics_dict

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -79,45 +79,6 @@ def test_calculate():
     ), f"Expected mostly_tracked_count_0.8 to be 2, got {result['mostly_tracked_count_0.8']}"
 
 
-def test_calculate_empty_inputs_with_exceptions():
-    """
-    Tests the calculate function for cases with empty inputs.
-
-    Ensures that ValueError is raised when:
-    - Both predictions and references are empty.
-    - Predictions are empty but references are non-empty.
-    - References are empty but predictions are non-empty.
-
-    Checks that the appropriate error message is provided for each case.
-    """
-    predictions = []
-    references = []
-
-    # Both empty
-    with pytest.raises(
-        ValueError,
-        match="The predictions should be a 2D array with 7 columns",
-    ):
-        calculate(predictions, references)
-
-    # Empty predictions, non-empty references
-    references = [[1, 1, 0.1, 0.2, 0.3, 0.4]]
-    with pytest.raises(
-        ValueError,
-        match="The predictions should be a 2D array with 7 columns",
-    ):
-        calculate(predictions, references)
-
-    # Empty references, non-empty predictions
-    predictions = [[1, 1, 0.1, 0.2, 0.3, 0.4, 0.9]]
-    references = []
-    with pytest.raises(
-        ValueError,
-        match="The references should be a 2D array with 6 columns",
-    ):
-        calculate(predictions, references)
-
-
 def test_calculate_invalid_shapes():
     # Invalid shape for predictions (missing confidence column)
     """
@@ -247,68 +208,6 @@ def test_calculate_mismatched_frames():
     assert result["unique_obj_count"] == 1, "Expected 1 unique GT ID"
 
 
-def test_calculate_empty_predictions_or_references():
-    # Empty predictions
-    """
-    Tests the calculate function with empty predictions or references.
-
-    Ensures that ValueError is raised when:
-    - Predictions are empty.
-    - References are empty.
-
-    Checks that the appropriate error message is provided for each case.
-    """
-    predictions = []
-    references = [[1, 1, 0.1, 0.2, 0.3, 0.4]]
-
-    with pytest.raises(
-        ValueError,
-        match="The predictions should be a 2D array with 7 columns",
-    ):
-        calculate(predictions, references)
-
-    # Empty references
-    predictions = [[1, 1, 0.1, 0.2, 0.3, 0.4, 0.9]]
-    references = []
-
-    with pytest.raises(
-        ValueError,
-        match="The references should be a 2D array with 6 columns",
-    ):
-        calculate(predictions, references)
-
-
-def test_calculate_none_inputs():
-    """
-    Tests the calculate function with None inputs.
-
-    Ensures that ValueError is raised when:
-    - Predictions are None.
-    - References are None.
-
-    Checks that the appropriate error message is provided for each case.
-    """
-    predictions = None
-    references = [[1, 1, 0.1, 0.2, 0.3, 0.4]]
-
-    # Test None predictions
-    with pytest.raises(
-        ValueError,
-        match="The predictions should be a 2D array with 7 columns",
-    ):
-        calculate(predictions, references)
-
-    predictions = [[1, 1, 0.1, 0.2, 0.3, 0.4, 0.9]]
-    references = None
-
-    # Test None references
-    with pytest.raises(
-        ValueError,
-        match="The references should be a 2D array with 6 columns",
-    ):
-        calculate(predictions, references)
-
-
 def test_sum_dicts():
     # Test 1: Simple dictionaries with overlapping keys
     """
@@ -417,15 +316,15 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert result["recall"] == 10 / (10 + 3), f"Expected recall, got {result['recall']}"
+    assert (math.isclose(result["recall"], 10 / (10 + 3), rel_tol=0.00001)), f"Expected recall, got {result['recall']}"
     assert (
-        result["mostly_tracked_score_0.3"] == 7 / 8
+        math.isclose(result["mostly_tracked_score_0.3"], 7/8, rel_tol=0.00001)
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["mostly_tracked_score_0.5"] == 6 / 8
+        math.isclose(result["mostly_tracked_score_0.5"], 6 / 8, rel_tol=0.00001)
     ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
     assert (
-        result["mostly_tracked_score_0.8"] == 4 / 8
+        math.isclose(result["mostly_tracked_score_0.8"], 4 / 8, rel_tol=0.00001)
     ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
 
     # Test 2: Edge case with zero TP, FP, FN
@@ -440,7 +339,9 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert np.isnan(result["recall"]), f"Expected recall NaN, got {result['recall']}"
+    assert (
+        math.isclose(result["recall"], 0, rel_tol=0.00001)
+    ), f"Expected recall NaN, got {result['recall']}"
     assert (
         result["mostly_tracked_score_0.3"] == 0
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
@@ -462,12 +363,14 @@ def test_realize_metrics():
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert result["recall"] == 5 / (5 + 2), f"Expected recall, got {result['recall']}"
     assert (
-        result["mostly_tracked_score_0.3"] == 3 / 10
+        math.isclose(result["recall"], 5 / (5 + 2), rel_tol=0.00001)
+    ), f"Expected recall, got {result['recall']}"
+    assert (
+        math.isclose(result["mostly_tracked_score_0.3"], 3 / 10, rel_tol=0.00001)
     ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["mostly_tracked_score_0.5"] == 1 / 10
+        math.isclose(result["mostly_tracked_score_0.5"], 1 / 10, rel_tol=0.00001)
     ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
 
     # Test 4: Large unique_obj_count with zero recognized
@@ -757,6 +660,7 @@ def test_calculate_from_payload():
     )
     
     global_metrics = output["model"]["overall"]["all"]
+    print(global_metrics)
     assert global_metrics["fn"] == 2.0, "False negatives mismatch"
     assert global_metrics["tp"] == 6.0, "True positives mismatch"
     assert (
@@ -764,13 +668,13 @@ def test_calculate_from_payload():
     ), "Number of ground truth IDs mismatch"
     assert math.isclose(global_metrics["recall"], 0.75, rel_tol=0.00001), "Recall mismatch"
     assert (
-        global_metrics["mostly_tracked_score_0.3"] == 1.0
+        math.isclose(global_metrics["mostly_tracked_score_0.3"], 1.0, rel_tol=0.00001)
     ), "Recognition at 0.3 mismatch"
     assert (
-        global_metrics["mostly_tracked_score_0.5"] == 1.0
+        math.isclose(global_metrics["mostly_tracked_score_0.5"], 1.0, rel_tol=0.00001)
     ), "Recognition at 0.5 mismatch"
     assert (
-        global_metrics["mostly_tracked_score_0.8"] == 0.5
+        math.isclose(global_metrics["mostly_tracked_score_0.8"], 0.5, rel_tol=0.00001)
     ), "Recognition at 0.8 mismatch"
     assert (
         global_metrics["mostly_tracked_count_0.3"] == 4
@@ -790,13 +694,13 @@ def test_calculate_from_payload():
     ), "Per-sequence ground truth IDs mismatch"
     assert math.isclose(sequence_metrics["recall"], 0.75, rel_tol=0.00001), "Per-sequence recall mismatch"
     assert (
-        sequence_metrics["mostly_tracked_score_0.3"] == 1.0
+        math.isclose(sequence_metrics["mostly_tracked_score_0.3"], 1.0, rel_tol=0.00001)
     ), "Per-sequence recognition at 0.3 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_score_0.5"] == 1.0
+        math.isclose(sequence_metrics["mostly_tracked_score_0.5"], 1.0, rel_tol=0.00001)
     ), "Per-sequence recognition at 0.5 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_score_0.8"] == 0.5
+        math.isclose(sequence_metrics["mostly_tracked_score_0.8"], 0.5, rel_tol=0.00001)
     ), "Per-sequence recognition at 0.8 mismatch"
     assert (
         sequence_metrics["mostly_tracked_count_0.3"] == 2


### PR DESCRIPTION
## What?

Remove 0 predictions and 0 ground_truth checks
 
## Why?
 
Even if there are 0 predictions or 0 ground_truth boxes, we want to calculate metrics. Also, this way no errors are raised during polymetrics calculations
 
## How?
 
The metrics engine can handle 0 gt or 0 preds, we just needed to pass an empty np array with the correct shape.
Because of this, some tests were changed.

## Backout plan

No backout should be needed, but the PR can be reverted as no input/output formats were changed.

## Testing

https://wandb.ai/sea-ai/uncategorized/runs/stappx8v?nw=nwuserseaaimlops

polymetrics manual run with empty gt and preditctions with the following config

```yaml
configuration_list:
  SEA-AI/user-friendly-metrics:
    enabled: true
    payload:
      dataset_name: "SENTRY_VIDEOS_DATASET_QA"
      gt_field: "ground_truth_det_fused_id"
      models:
        - "cerulean_level_17_11_2023_RL_SPLIT_LN1_ep147_pb_8bf6985_swept_microwave_103_oversea"
      data_type: "thermal"
      tracking_mode: true
      sequence_list: ["PROACT_CELADON_S@6m_FB_SUNRISE_20230720_2023_02_07_17_56_01"]
              
    evaluate:
      filter: {
            "name": "area",
            "ranges": [["all", [0, 1638400]], ["small", [0, 36]], ["medium", [36, 144]], ["large", [144, 1638400]]]
            }

fiftyone:
  upload: true
```