### PR TITLE
change the dots (.) with underscore in the output of the user-friendly metrics

### DIFF
--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -129,13 +129,16 @@ def recursively_change_dots_for_underscore(dict_arg_name="metrics"):
     return decorator
 
 
-def _has_dots(data: Dict[str, Dict]) -> bool:
+def _has_dots(data: Dict) -> bool:
     """Check if any key contains a dot in a dictionary."""
-    return any(
-        "." in key or _has_dots(value)
-        for key, value in data.items()
-        if isinstance(value, dict)
-    )
+    for key, value in data.items():
+        # Check if the current key contains a dot
+        if "." in key:
+            return True
+        # Recursively check nested dictionaries
+        if isinstance(value, dict) and _has_dots(value):
+            return True
+    return False
 
 
 def _replace_dots_in_keys(data: Dict[str, Dict]) -> Dict[str, Dict]:

--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -100,16 +100,21 @@ def recursively_change_dots_for_underscore(func):
     """Decorator to replace dots in dictionary keys with underscores in the 'metrics' argument."""
 
     def wrapper(*args, **kwargs):
+        # Extract `metrics` from kwargs or args
         metrics = kwargs.get("metrics", args[1] if len(args) > 1 else None)
         if metrics and _has_dots(metrics):
             logging.warning(
                 "Dot (.) found in keys. Replacing with underscores (_) in metrics."
             )
             metrics = _replace_dots_in_keys(metrics)
+
+        # Update kwargs or rebuild args with modified metrics
         if "metrics" in kwargs:
             kwargs["metrics"] = metrics
+            return func(*args, **kwargs)
         elif len(args) > 1:
-            args = args[:1] + (metrics,) + args[2:]
+            new_args = args[:1] + (metrics,) + args[2:]
+            return func(*new_args, **kwargs)
         return func(*args, **kwargs)
 
     return wrapper

--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -96,31 +96,40 @@ def _update_sample_metrics(
     sample.save()
 
 
-def recursively_change_dots_for_underscore(func):
-    """Decorator to replace dots in dictionary keys with underscores in the 'metrics' argument."""
+def recursively_change_dots_for_underscore(dict_arg_name="metrics"):
+    """
+    Decorator to replace dots in dictionary keys with underscores
+    in the specified keyword argument.
+    """
 
-    def wrapper(*args, **kwargs):
-        # Extract `metrics` from kwargs or args
-        metrics = kwargs.get("metrics", args[1] if len(args) > 1 else None)
-        if metrics and _has_dots(metrics):
-            logging.warning(
-                "Dot (.) found in keys. Replacing with underscores (_) in metrics."
-            )
-            metrics = _replace_dots_in_keys(metrics)
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            # Check if the specified keyword argument exists in kwargs
+            if dict_arg_name not in kwargs:
+                logging.info(
+                    "Keyword argument '%s' not found in function call. Skipping modification.",
+                    dict_arg_name,
+                )
+                return func(*args, **kwargs)  # Exit gracefully if not found
 
-        # Update kwargs or rebuild args with modified metrics
-        if "metrics" in kwargs:
-            kwargs["metrics"] = metrics
+            # Get the target data
+            target_data = kwargs[dict_arg_name]
+
+            if target_data and _has_dots(target_data):
+                logging.warning(
+                    "Dot (.) found in keys. Replacing with underscores (_) in '%s'.",
+                    dict_arg_name,
+                )
+                kwargs[dict_arg_name] = _replace_dots_in_keys(target_data)
+
             return func(*args, **kwargs)
-        elif len(args) > 1:
-            new_args = args[:1] + (metrics,) + args[2:]
-            return func(*new_args, **kwargs)
-        return func(*args, **kwargs)
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
-def _has_dots(data: Dict[str, Any]) -> bool:
+def _has_dots(data: Dict[str, Dict]) -> bool:
     """Check if any key contains a dot in a dictionary."""
     return any(
         "." in key or _has_dots(value)
@@ -129,7 +138,7 @@ def _has_dots(data: Dict[str, Any]) -> bool:
     )
 
 
-def _replace_dots_in_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+def _replace_dots_in_keys(data: Dict[str, Dict]) -> Dict[str, Dict]:
     """Recursively replace dots in dictionary keys with underscores."""
     return {
         key.replace(".", "_"): (
@@ -139,7 +148,7 @@ def _replace_dots_in_keys(data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-@recursively_change_dots_for_underscore
+@recursively_change_dots_for_underscore(dict_arg_name="metrics")
 def fo_upload(
     dataset_name: str,
     metrics: Dict[str, Dict],

--- a/seametrics/fo_utils/utils.py
+++ b/seametrics/fo_utils/utils.py
@@ -96,6 +96,45 @@ def _update_sample_metrics(
     sample.save()
 
 
+def recursively_change_dots_for_underscore(func):
+    """Decorator to replace dots in dictionary keys with underscores in the 'metrics' argument."""
+
+    def wrapper(*args, **kwargs):
+        metrics = kwargs.get("metrics", args[1] if len(args) > 1 else None)
+        if metrics and _has_dots(metrics):
+            logging.warning(
+                "Dot (.) found in keys. Replacing with underscores (_) in metrics."
+            )
+            metrics = _replace_dots_in_keys(metrics)
+        if "metrics" in kwargs:
+            kwargs["metrics"] = metrics
+        elif len(args) > 1:
+            args = args[:1] + (metrics,) + args[2:]
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _has_dots(data: Dict[str, Any]) -> bool:
+    """Check if any key contains a dot in a dictionary."""
+    return any(
+        "." in key or _has_dots(value)
+        for key, value in data.items()
+        if isinstance(value, dict)
+    )
+
+
+def _replace_dots_in_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively replace dots in dictionary keys with underscores."""
+    return {
+        key.replace(".", "_"): (
+            _replace_dots_in_keys(value) if isinstance(value, dict) else value
+        )
+        for key, value in data.items()
+    }
+
+
+@recursively_change_dots_for_underscore
 def fo_upload(
     dataset_name: str,
     metrics: Dict[str, Dict],

--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -12,6 +12,7 @@ def unique_obj_count(df):
     """Number of unique gt ids."""
     return df.full["OId"].dropna().unique().shape[0]
 
+
 def trasform_inputs(predictions, references):
 
     try:
@@ -28,9 +29,7 @@ def trasform_inputs(predictions, references):
             "The references should be a list of np.arrays in the format [frame number, object id, bb_left, bb_top, bb_width, bb_height]"
         )
 
-    if (
-        np_predictions.ndim < 2 or np_predictions.shape[1] != 7
-    ):
+    if np_predictions.ndim < 2 or np_predictions.shape[1] != 7:
         raise ValueError(
             "The predictions should be a 2D array with 7 columns in the format [frame number, object id, bb_left, bb_top, bb_width, bb_height, confidence]"
         )
@@ -41,17 +40,18 @@ def trasform_inputs(predictions, references):
         )
 
     if np_predictions.size > 0:
-        if np_predictions[:, 0].min() <= 0 :
+        if np_predictions[:, 0].min() <= 0:
             raise ValueError(
                 "The frame number in the predictions should be a positive integer"
-        )
+            )
     if np_references.size > 0:
         if np_references[:, 0].min() <= 0:
             raise ValueError(
                 "The frame number in the references should be a positive integer"
-        )
+            )
 
     return np_predictions, np_references
+
 
 def calculate(
     predictions,
@@ -62,10 +62,10 @@ def calculate(
     """Returns the scores"""
 
     np_predictions, np_references = trasform_inputs(predictions, references)
-    
+
     reference_frames = np_references[:, 0].max() if np_references.size > 0 else 0
     prediction_frames = np_predictions[:, 0].max() if np_predictions.size > 0 else 0
-    
+
     num_frames = int(max(reference_frames, prediction_frames))
 
     acc = mm.MOTAccumulator(auto_id=True)
@@ -81,9 +81,7 @@ def calculate(
         )
 
     mh = mm.metrics.create()
-    summary = mh.compute(
-        acc, metrics=["num_misses", "num_detections"]
-    ).to_dict()
+    summary = mh.compute(acc, metrics=["num_misses", "num_detections"]).to_dict()
 
     df = events_to_df_map(acc.events)
     tr_ratios = track_ratios(df, obj_frequencies(df))
@@ -102,7 +100,7 @@ def calculate(
 
     for th in recognition_thresholds:
         recognized = recognition(tr_ratios, th)
-        summary[f"mostly_tracked_count_{th}"] = int(recognized)
+        summary[f"mostly_tracked_count_{str(th).replace('.', '_')}"] = int(recognized)
 
     return summary
 
@@ -115,9 +113,10 @@ def build_metrics_template(filter):
         metrics_dict[filter_range_name] = {}
     return metrics_dict
 
+
 def get_formated_references(frames, filter):
     """formats the references for the calculate_from_payload function, based on the filter and its ranges"""
-    
+
     filter_name = filter["name"]
     filter_ranges = filter["ranges"]
     formated_references = {}
@@ -147,6 +146,7 @@ def get_formated_references(frames, filter):
 
     return formated_references
 
+
 def get_formated_predictions(frames):
     """formats the predictions for the calculate_from_payload function"""
     formated_predictions = []
@@ -155,18 +155,18 @@ def get_formated_predictions(frames):
             index = detection["index"]
             x, y, w, h = detection["bounding_box"]
             confidence = 1
-            formated_predictions.append(
-                [frame_id + 1, index, x, y, w, h, confidence]
-            )
+            formated_predictions.append([frame_id + 1, index, x, y, w, h, confidence])
 
     return formated_predictions
 
-def calculate_from_payload(payload: dict,
-                        max_iou: float = 0.5, 
-                        filter={"name": "area", 
-                                "ranges": [("all", [0, 1e5**2])]},
-                        recognition_thresholds=[0.3, 0.5, 0.8], 
-                        debug: bool = False):
+
+def calculate_from_payload(
+    payload: dict,
+    max_iou: float = 0.5,
+    filter={"name": "area", "ranges": [("all", [0, 1e5**2])]},
+    recognition_thresholds=[0.3, 0.5, 0.8],
+    debug: bool = False,
+):
     """
     Filter in the form of:
     {
@@ -176,7 +176,7 @@ def calculate_from_payload(payload: dict,
 
     Receives a payload and returns the metrics
     """
-    
+
     filter_name = filter["name"]
     filter_ranges = filter["ranges"]
     output = {}
@@ -197,7 +197,7 @@ def calculate_from_payload(payload: dict,
         print("gt_field_name: ", gt_field_name)
         print("models: ", models)
         print("sequence_list: ", sequence_list)
-    
+
     for model in models:
 
         metrics_overall = build_metrics_template(filter["ranges"])
@@ -205,7 +205,7 @@ def calculate_from_payload(payload: dict,
         for sequence in sequence_list:
 
             metrics_per_sequence[sequence] = build_metrics_template(filter["ranges"])
-            
+
             frames = payload["sequences"][sequence][gt_field_name]
             formated_references = get_formated_references(frames, filter)
 
@@ -213,7 +213,7 @@ def calculate_from_payload(payload: dict,
             formated_predictions = get_formated_predictions(frames)
 
             for filter_range in filter_ranges:
-                
+
                 filter_range_name = filter_range[0]
 
                 sequence_metrics = calculate(
@@ -237,14 +237,13 @@ def calculate_from_payload(payload: dict,
                     metrics_overall[filter_range_name],
                     recognition_thresholds,
                 )
-                
+
         output[model] = {
             "per_sequence": metrics_per_sequence,
             "overall": metrics_overall,
         }
 
     return output
-            
 
 
 def sum_dicts(dict1, dict2):
@@ -277,9 +276,9 @@ def realize_metrics(metrics_dict, recognition_thresholds):
     )
 
     for th in recognition_thresholds:
-        metrics_dict[f"mostly_tracked_score_{th}"] = (
-            metrics_dict[f"mostly_tracked_count_{th}"]
-            / (metrics_dict["unique_obj_count"]+1e-6)
-        )
+        th_str = str(th).replace(".", "_")
+        metrics_dict[f"mostly_tracked_score_{th_str}"] = metrics_dict[
+            f"mostly_tracked_count_{th_str}"
+        ] / (metrics_dict["unique_obj_count"] + 1e-6)
 
     return metrics_dict

--- a/seametrics/user_friendly/utils.py
+++ b/seametrics/user_friendly/utils.py
@@ -100,7 +100,7 @@ def calculate(
 
     for th in recognition_thresholds:
         recognized = recognition(tr_ratios, th)
-        summary[f"mostly_tracked_count_{str(th).replace('.', '_')}"] = int(recognized)
+        summary[f"mostly_tracked_count_{th}"] = int(recognized)
 
     return summary
 
@@ -276,9 +276,8 @@ def realize_metrics(metrics_dict, recognition_thresholds):
     )
 
     for th in recognition_thresholds:
-        th_str = str(th).replace(".", "_")
-        metrics_dict[f"mostly_tracked_score_{th_str}"] = metrics_dict[
-            f"mostly_tracked_count_{th_str}"
+        metrics_dict[f"mostly_tracked_score_{th}"] = metrics_dict[
+            f"mostly_tracked_count_{th}"
         ] / (metrics_dict["unique_obj_count"] + 1e-6)
 
     return metrics_dict

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -1,4 +1,5 @@
 import math
+from pprint import pprint
 
 import motmetrics as mm
 import numpy as np
@@ -16,7 +17,6 @@ from seametrics.user_friendly.utils import (
     unique_obj_count,
 )
 
-from pprint import pprint
 
 def test_recognition():
     """
@@ -69,14 +69,14 @@ def test_calculate():
         result["unique_obj_count"] == 2
     ), f"Expected unique_obj_count to be 2, got {result['unique_obj_count']}"
     assert (
-        result["mostly_tracked_count_0.3"] == 2
-    ), f"Expected mostly_tracked_count_0.3 to be 2, got {result['mostly_tracked_count_0.3']}"
+        result["mostly_tracked_count_0_3"] == 2
+    ), f"Expected mostly_tracked_count_0_3 to be 2, got {result['mostly_tracked_count_0_3']}"
     assert (
-        result["mostly_tracked_count_0.5"] == 2
-    ), f"Expected mostly_tracked_count_0.5 to be 2, got {result['mostly_tracked_count_0.5']}"
+        result["mostly_tracked_count_0_5"] == 2
+    ), f"Expected mostly_tracked_count_0_5 to be 2, got {result['mostly_tracked_count_0_5']}"
     assert (
-        result["mostly_tracked_count_0.8"] == 2
-    ), f"Expected mostly_tracked_count_0.8 to be 2, got {result['mostly_tracked_count_0.8']}"
+        result["mostly_tracked_count_0_8"] == 2
+    ), f"Expected mostly_tracked_count_0_8 to be 2, got {result['mostly_tracked_count_0_8']}"
 
 
 def test_calculate_invalid_shapes():
@@ -276,19 +276,18 @@ def test_build_metrics_template():
     5. Large number of models and filters.
     """
 
-    filter_input = {"name": "area", 
-            "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]}
-    
-    expected = {
-            "all": {},
-            "small": {}}
-    
+    filter_input = {
+        "name": "area",
+        "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])],
+    }
+
+    expected = {"all": {}, "small": {}}
+
     result = build_metrics_template(filter_input["ranges"])
     assert result == expected, f"Test 1 failed: {result}"
 
     # Test 2: Empty filter
-    filter_input = {"name": "area",
-            "ranges": []}
+    filter_input = {"name": "area", "ranges": []}
     expected = {}
     result = build_metrics_template(filter_input["ranges"])
     assert result == expected, f"Test 2 failed: {result}"
@@ -309,88 +308,90 @@ def test_realize_metrics():
         "tp": 10,
         "fn": 3,
         "unique_obj_count": 8,
-        "mostly_tracked_count_0.3": 7,
-        "mostly_tracked_count_0.5": 6,
-        "mostly_tracked_count_0.8": 4,
+        "mostly_tracked_count_0_3": 7,
+        "mostly_tracked_count_0_5": 6,
+        "mostly_tracked_count_0_8": 4,
     }
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert (math.isclose(result["recall"], 10 / (10 + 3), rel_tol=0.00001)), f"Expected recall, got {result['recall']}"
-    assert (
-        math.isclose(result["mostly_tracked_score_0.3"], 7/8, rel_tol=0.00001)
-    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
-    assert (
-        math.isclose(result["mostly_tracked_score_0.5"], 6 / 8, rel_tol=0.00001)
-    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
-    assert (
-        math.isclose(result["mostly_tracked_score_0.8"], 4 / 8, rel_tol=0.00001)
-    ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
+    assert math.isclose(
+        result["recall"], 10 / (10 + 3), rel_tol=0.00001
+    ), f"Expected recall, got {result['recall']}"
+    assert math.isclose(
+        result["mostly_tracked_score_0_3"], 7 / 8, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
+    assert math.isclose(
+        result["mostly_tracked_score_0_5"], 6 / 8, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
+    assert math.isclose(
+        result["mostly_tracked_score_0_8"], 4 / 8, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0_8, got {result['mostly_tracked_score_0_8']}"
 
     # Test 2: Edge case with zero TP, FP, FN
     metrics_dict = {
         "tp": 0,
         "fn": 0,
         "unique_obj_count": 1,
-        "mostly_tracked_count_0.3": 0,
-        "mostly_tracked_count_0.5": 0,
-        "mostly_tracked_count_0.8": 0,
+        "mostly_tracked_count_0_3": 0,
+        "mostly_tracked_count_0_5": 0,
+        "mostly_tracked_count_0_8": 0,
     }
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert (
-        math.isclose(result["recall"], 0, rel_tol=0.00001)
+    assert math.isclose(
+        result["recall"], 0, rel_tol=0.00001
     ), f"Expected recall NaN, got {result['recall']}"
     assert (
-        result["mostly_tracked_score_0.3"] == 0
-    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
+        result["mostly_tracked_score_0_3"] == 0
+    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
     assert (
-        result["mostly_tracked_score_0.5"] == 0
-    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
+        result["mostly_tracked_score_0_5"] == 0
+    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
     assert (
-        result["mostly_tracked_score_0.8"] == 0
-    ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
+        result["mostly_tracked_score_0_8"] == 0
+    ), f"Expected mostly_tracked_score_0_8, got {result['mostly_tracked_score_0_8']}"
 
     # Test 3: Zero FP but non-zero TP
     metrics_dict = {
         "tp": 5,
         "fn": 2,
         "unique_obj_count": 10,
-        "mostly_tracked_count_0.3": 3,
-        "mostly_tracked_count_0.5": 1,
+        "mostly_tracked_count_0_3": 3,
+        "mostly_tracked_count_0_5": 1,
     }
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
-    assert (
-        math.isclose(result["recall"], 5 / (5 + 2), rel_tol=0.00001)
+    assert math.isclose(
+        result["recall"], 5 / (5 + 2), rel_tol=0.00001
     ), f"Expected recall, got {result['recall']}"
-    assert (
-        math.isclose(result["mostly_tracked_score_0.3"], 3 / 10, rel_tol=0.00001)
-    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
-    assert (
-        math.isclose(result["mostly_tracked_score_0.5"], 1 / 10, rel_tol=0.00001)
-    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
+    assert math.isclose(
+        result["mostly_tracked_score_0_3"], 3 / 10, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
+    assert math.isclose(
+        result["mostly_tracked_score_0_5"], 1 / 10, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
 
     # Test 4: Large unique_obj_count with zero recognized
     metrics_dict = {
         "tp": 0,
         "fn": 5,
         "unique_obj_count": 1000,
-        "mostly_tracked_count_0.3": 0,
-        "mostly_tracked_count_0.5": 0,
+        "mostly_tracked_count_0_3": 0,
+        "mostly_tracked_count_0_5": 0,
     }
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
     assert result["recall"] == 0, f"Expected recall 0, got {result['recall']}"
     assert (
-        result["mostly_tracked_score_0.3"] == 0
-    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
+        result["mostly_tracked_score_0_3"] == 0
+    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
     assert (
-        result["mostly_tracked_score_0.5"] == 0
-    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
+        result["mostly_tracked_score_0_5"] == 0
+    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
 
 
 def test_unique_obj_count():
@@ -639,7 +640,7 @@ def test_calculate_from_payload():
                         [mock_detections_b[i] for i in range(n_detections)]
                         for n_detections in model_config
                     ],
-                ),        
+                ),
             },
         )
 
@@ -652,13 +653,12 @@ def test_calculate_from_payload():
 
     output = calculate_from_payload(
         payload=payload,
-        filter={"name": "area", 
-                "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]},
+        filter={"name": "area", "ranges": [("all", [0, 1e5**2]), ("small", [0, 6**2])]},
         max_iou=max_iou,
         recognition_thresholds=recognition_thresholds,
         debug=debug,
     )
-    
+
     global_metrics = output["model"]["overall"]["all"]
     print(global_metrics)
     assert global_metrics["fn"] == 2.0, "False negatives mismatch"
@@ -666,24 +666,26 @@ def test_calculate_from_payload():
     assert (
         global_metrics["unique_obj_count"] == 4
     ), "Number of ground truth IDs mismatch"
-    assert math.isclose(global_metrics["recall"], 0.75, rel_tol=0.00001), "Recall mismatch"
-    assert (
-        math.isclose(global_metrics["mostly_tracked_score_0.3"], 1.0, rel_tol=0.00001)
+    assert math.isclose(
+        global_metrics["recall"], 0.75, rel_tol=0.00001
+    ), "Recall mismatch"
+    assert math.isclose(
+        global_metrics["mostly_tracked_score_0_3"], 1.0, rel_tol=0.00001
     ), "Recognition at 0.3 mismatch"
-    assert (
-        math.isclose(global_metrics["mostly_tracked_score_0.5"], 1.0, rel_tol=0.00001)
+    assert math.isclose(
+        global_metrics["mostly_tracked_score_0_5"], 1.0, rel_tol=0.00001
     ), "Recognition at 0.5 mismatch"
-    assert (
-        math.isclose(global_metrics["mostly_tracked_score_0.8"], 0.5, rel_tol=0.00001)
+    assert math.isclose(
+        global_metrics["mostly_tracked_score_0_8"], 0.5, rel_tol=0.00001
     ), "Recognition at 0.8 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0.3"] == 4
+        global_metrics["mostly_tracked_count_0_3"] == 4
     ), "Recognized count at 0.3 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0.5"] == 4
+        global_metrics["mostly_tracked_count_0_5"] == 4
     ), "Recognized count at 0.5 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0.8"] == 2
+        global_metrics["mostly_tracked_count_0_8"] == 2
     ), "Recognized count at 0.8 mismatch"
 
     sequence_metrics = output["model"]["per_sequence"]["sequence_a"]["all"]
@@ -692,22 +694,24 @@ def test_calculate_from_payload():
     assert (
         sequence_metrics["unique_obj_count"] == 2
     ), "Per-sequence ground truth IDs mismatch"
-    assert math.isclose(sequence_metrics["recall"], 0.75, rel_tol=0.00001), "Per-sequence recall mismatch"
-    assert (
-        math.isclose(sequence_metrics["mostly_tracked_score_0.3"], 1.0, rel_tol=0.00001)
+    assert math.isclose(
+        sequence_metrics["recall"], 0.75, rel_tol=0.00001
+    ), "Per-sequence recall mismatch"
+    assert math.isclose(
+        sequence_metrics["mostly_tracked_score_0_3"], 1.0, rel_tol=0.00001
     ), "Per-sequence recognition at 0.3 mismatch"
-    assert (
-        math.isclose(sequence_metrics["mostly_tracked_score_0.5"], 1.0, rel_tol=0.00001)
+    assert math.isclose(
+        sequence_metrics["mostly_tracked_score_0_5"], 1.0, rel_tol=0.00001
     ), "Per-sequence recognition at 0.5 mismatch"
-    assert (
-        math.isclose(sequence_metrics["mostly_tracked_score_0.8"], 0.5, rel_tol=0.00001)
+    assert math.isclose(
+        sequence_metrics["mostly_tracked_score_0_8"], 0.5, rel_tol=0.00001
     ), "Per-sequence recognition at 0.8 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0.3"] == 2
+        sequence_metrics["mostly_tracked_count_0_3"] == 2
     ), "Per-sequence recognized count at 0.3 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0.5"] == 2
+        sequence_metrics["mostly_tracked_count_0_5"] == 2
     ), "Per-sequence recognized count at 0.5 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0.8"] == 1
+        sequence_metrics["mostly_tracked_count_0_8"] == 1
     ), "Per-sequence recognized count at 0.8 mismatch"

--- a/tests/user_friendly/test_uf_utils.py
+++ b/tests/user_friendly/test_uf_utils.py
@@ -69,14 +69,14 @@ def test_calculate():
         result["unique_obj_count"] == 2
     ), f"Expected unique_obj_count to be 2, got {result['unique_obj_count']}"
     assert (
-        result["mostly_tracked_count_0_3"] == 2
-    ), f"Expected mostly_tracked_count_0_3 to be 2, got {result['mostly_tracked_count_0_3']}"
+        result["mostly_tracked_count_0.3"] == 2
+    ), f"Expected mostly_tracked_count_0.3 to be 2, got {result['mostly_tracked_count_0.3']}"
     assert (
-        result["mostly_tracked_count_0_5"] == 2
-    ), f"Expected mostly_tracked_count_0_5 to be 2, got {result['mostly_tracked_count_0_5']}"
+        result["mostly_tracked_count_0.5"] == 2
+    ), f"Expected mostly_tracked_count_0.5 to be 2, got {result['mostly_tracked_count_0.5']}"
     assert (
-        result["mostly_tracked_count_0_8"] == 2
-    ), f"Expected mostly_tracked_count_0_8 to be 2, got {result['mostly_tracked_count_0_8']}"
+        result["mostly_tracked_count_0.8"] == 2
+    ), f"Expected mostly_tracked_count_0.8 to be 2, got {result['mostly_tracked_count_0.8']}"
 
 
 def test_calculate_invalid_shapes():
@@ -308,9 +308,9 @@ def test_realize_metrics():
         "tp": 10,
         "fn": 3,
         "unique_obj_count": 8,
-        "mostly_tracked_count_0_3": 7,
-        "mostly_tracked_count_0_5": 6,
-        "mostly_tracked_count_0_8": 4,
+        "mostly_tracked_count_0.3": 7,
+        "mostly_tracked_count_0.5": 6,
+        "mostly_tracked_count_0.8": 4,
     }
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
@@ -319,23 +319,23 @@ def test_realize_metrics():
         result["recall"], 10 / (10 + 3), rel_tol=0.00001
     ), f"Expected recall, got {result['recall']}"
     assert math.isclose(
-        result["mostly_tracked_score_0_3"], 7 / 8, rel_tol=0.00001
-    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
+        result["mostly_tracked_score_0.3"], 7 / 8, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert math.isclose(
-        result["mostly_tracked_score_0_5"], 6 / 8, rel_tol=0.00001
-    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
+        result["mostly_tracked_score_0.5"], 6 / 8, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
     assert math.isclose(
-        result["mostly_tracked_score_0_8"], 4 / 8, rel_tol=0.00001
-    ), f"Expected mostly_tracked_score_0_8, got {result['mostly_tracked_score_0_8']}"
+        result["mostly_tracked_score_0.8"], 4 / 8, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
 
     # Test 2: Edge case with zero TP, FP, FN
     metrics_dict = {
         "tp": 0,
         "fn": 0,
         "unique_obj_count": 1,
-        "mostly_tracked_count_0_3": 0,
-        "mostly_tracked_count_0_5": 0,
-        "mostly_tracked_count_0_8": 0,
+        "mostly_tracked_count_0.3": 0,
+        "mostly_tracked_count_0.5": 0,
+        "mostly_tracked_count_0.8": 0,
     }
     recognition_thresholds = [0.3, 0.5, 0.8]
     result = realize_metrics(metrics_dict, recognition_thresholds)
@@ -344,22 +344,22 @@ def test_realize_metrics():
         result["recall"], 0, rel_tol=0.00001
     ), f"Expected recall NaN, got {result['recall']}"
     assert (
-        result["mostly_tracked_score_0_3"] == 0
-    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
+        result["mostly_tracked_score_0.3"] == 0
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["mostly_tracked_score_0_5"] == 0
-    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
+        result["mostly_tracked_score_0.5"] == 0
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
     assert (
-        result["mostly_tracked_score_0_8"] == 0
-    ), f"Expected mostly_tracked_score_0_8, got {result['mostly_tracked_score_0_8']}"
+        result["mostly_tracked_score_0.8"] == 0
+    ), f"Expected mostly_tracked_score_0.8, got {result['mostly_tracked_score_0.8']}"
 
     # Test 3: Zero FP but non-zero TP
     metrics_dict = {
         "tp": 5,
         "fn": 2,
         "unique_obj_count": 10,
-        "mostly_tracked_count_0_3": 3,
-        "mostly_tracked_count_0_5": 1,
+        "mostly_tracked_count_0.3": 3,
+        "mostly_tracked_count_0.5": 1,
     }
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
@@ -368,30 +368,30 @@ def test_realize_metrics():
         result["recall"], 5 / (5 + 2), rel_tol=0.00001
     ), f"Expected recall, got {result['recall']}"
     assert math.isclose(
-        result["mostly_tracked_score_0_3"], 3 / 10, rel_tol=0.00001
-    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
+        result["mostly_tracked_score_0.3"], 3 / 10, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert math.isclose(
-        result["mostly_tracked_score_0_5"], 1 / 10, rel_tol=0.00001
-    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
+        result["mostly_tracked_score_0.5"], 1 / 10, rel_tol=0.00001
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
 
     # Test 4: Large unique_obj_count with zero recognized
     metrics_dict = {
         "tp": 0,
         "fn": 5,
         "unique_obj_count": 1000,
-        "mostly_tracked_count_0_3": 0,
-        "mostly_tracked_count_0_5": 0,
+        "mostly_tracked_count_0.3": 0,
+        "mostly_tracked_count_0.5": 0,
     }
     recognition_thresholds = [0.3, 0.5]
     result = realize_metrics(metrics_dict, recognition_thresholds)
 
     assert result["recall"] == 0, f"Expected recall 0, got {result['recall']}"
     assert (
-        result["mostly_tracked_score_0_3"] == 0
-    ), f"Expected mostly_tracked_score_0_3, got {result['mostly_tracked_score_0_3']}"
+        result["mostly_tracked_score_0.3"] == 0
+    ), f"Expected mostly_tracked_score_0.3, got {result['mostly_tracked_score_0.3']}"
     assert (
-        result["mostly_tracked_score_0_5"] == 0
-    ), f"Expected mostly_tracked_score_0_5, got {result['mostly_tracked_score_0_5']}"
+        result["mostly_tracked_score_0.5"] == 0
+    ), f"Expected mostly_tracked_score_0.5, got {result['mostly_tracked_score_0.5']}"
 
 
 def test_unique_obj_count():
@@ -670,22 +670,22 @@ def test_calculate_from_payload():
         global_metrics["recall"], 0.75, rel_tol=0.00001
     ), "Recall mismatch"
     assert math.isclose(
-        global_metrics["mostly_tracked_score_0_3"], 1.0, rel_tol=0.00001
+        global_metrics["mostly_tracked_score_0.3"], 1.0, rel_tol=0.00001
     ), "Recognition at 0.3 mismatch"
     assert math.isclose(
-        global_metrics["mostly_tracked_score_0_5"], 1.0, rel_tol=0.00001
+        global_metrics["mostly_tracked_score_0.5"], 1.0, rel_tol=0.00001
     ), "Recognition at 0.5 mismatch"
     assert math.isclose(
-        global_metrics["mostly_tracked_score_0_8"], 0.5, rel_tol=0.00001
+        global_metrics["mostly_tracked_score_0.8"], 0.5, rel_tol=0.00001
     ), "Recognition at 0.8 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0_3"] == 4
+        global_metrics["mostly_tracked_count_0.3"] == 4
     ), "Recognized count at 0.3 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0_5"] == 4
+        global_metrics["mostly_tracked_count_0.5"] == 4
     ), "Recognized count at 0.5 mismatch"
     assert (
-        global_metrics["mostly_tracked_count_0_8"] == 2
+        global_metrics["mostly_tracked_count_0.8"] == 2
     ), "Recognized count at 0.8 mismatch"
 
     sequence_metrics = output["model"]["per_sequence"]["sequence_a"]["all"]
@@ -698,20 +698,20 @@ def test_calculate_from_payload():
         sequence_metrics["recall"], 0.75, rel_tol=0.00001
     ), "Per-sequence recall mismatch"
     assert math.isclose(
-        sequence_metrics["mostly_tracked_score_0_3"], 1.0, rel_tol=0.00001
+        sequence_metrics["mostly_tracked_score_0.3"], 1.0, rel_tol=0.00001
     ), "Per-sequence recognition at 0.3 mismatch"
     assert math.isclose(
-        sequence_metrics["mostly_tracked_score_0_5"], 1.0, rel_tol=0.00001
+        sequence_metrics["mostly_tracked_score_0.5"], 1.0, rel_tol=0.00001
     ), "Per-sequence recognition at 0.5 mismatch"
     assert math.isclose(
-        sequence_metrics["mostly_tracked_score_0_8"], 0.5, rel_tol=0.00001
+        sequence_metrics["mostly_tracked_score_0.8"], 0.5, rel_tol=0.00001
     ), "Per-sequence recognition at 0.8 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0_3"] == 2
+        sequence_metrics["mostly_tracked_count_0.3"] == 2
     ), "Per-sequence recognized count at 0.3 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0_5"] == 2
+        sequence_metrics["mostly_tracked_count_0.5"] == 2
     ), "Per-sequence recognized count at 0.5 mismatch"
     assert (
-        sequence_metrics["mostly_tracked_count_0_8"] == 1
+        sequence_metrics["mostly_tracked_count_0.8"] == 1
     ), "Per-sequence recognized count at 0.8 mismatch"


### PR DESCRIPTION
## What?

Update all the dots in the dict keys with an underscore before uploading to FiftyOne
 
## Why?

The aggregation functions in fiftyone are not working on fields with dots (.) 
 
## How?
 
Added a decorator for the fiftyone upload functions in `fo_utils/utils.py` which replace the dots (.) in decimal thresholds (e.g., 0.3) with underscores (_).

```python
key = key.replace('.', '_')
```

Example:

```diff
- mostly_tracked_count_0.3
+ mostly_tracked_count_0_3
```

## Backout plan

not applicable, easy to reverse

## Testing
 
![image](https://github.com/user-attachments/assets/fb6e8d1a-4205-48c6-a176-0caa4223153c)



