### PR TITLE
Update SonarQube GitHub Action to use the correct repository

### DIFF
--- a/.github/workflows/sonar-cloud.yaml
+++ b/.github/workflows/sonar-cloud.yaml
@@ -52,9 +52,9 @@ jobs:
           source .venv/bin/activate
           pytest --cov=seametrics --cov-report=xml
 
-      # Step 6: SonarCloud scan
+      # Step 6: SonarQube Cloud scan
       - name: 🔎 SonarQube Cloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for PR analysis
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## What?

Update deprecated SonarCloud GitHub Action.

## Why?

The previously used version was deprecated, as SonarCloud has been renamed to SonarQube Cloud. Along with this change, the GitHub Action name was also updated. The old action name was no longer valid, causing the pipeline to fail.

## How?

Renamed the step from `"SonarCloud scan"` to `"SonarQube Cloud scan"` and updated the action from  
`SonarSource/sonarcloud-github-action@master` to `SonarSource/sonarqube-scan-action@master`.

## Backout Plan
🙅‍♀️

## Testing

The renaming was already applied to the `seavision` repository, where it worked.

![image](https://github.com/user-attachments/assets/26fd2e4a-97ee-4902-922d-fce0deedfad6)
