### PR TITLE
DATA-317: add optional confidence filtering to model fields

### DIFF
--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -29,7 +29,8 @@ class PayloadProcessor:
         slices: List[str] = None,
         tags: List[str] = None,
         start_frame_id: int = None,
-        end_frame_id: int = None
+        end_frame_id: int = None,
+        confidence_threshold: float = 0
     ):
         """
         Initializes a PayloadProcessor object.
@@ -50,8 +51,12 @@ class PayloadProcessor:
                 Defaults to None. If None, a smart selection of available slices takes place.
             tags (List[str], optional): The list of tags to filter the dataset.
                 Defaults to None.
-            start_frame_id (int, optional): The start frame id. Defaults to None.
-            end_frame_id (int, optional): The end frame id. Defaults to None.
+            start_frame_id (int, optional): The start frame id.
+                Defaults to None.
+            end_frame_id (int, optional): The end frame id.
+                Defaults to None.
+            confidence_threshold (float, optional): Confidence threshold to filter the model fields.
+                Defaults to 0.
         """
         self.dataset_name = dataset_name
         self.gt_field = gt_field
@@ -61,6 +66,7 @@ class PayloadProcessor:
         self.data_type = data_type
         self.slices = slices
         self.tags = tags
+        self.confidence_threshold = confidence_threshold
         self.excluded_classes = excluded_classes or EXCLUDED_CLASSES
         self.validate_input_parameters()
         self.dataset: fo.Dataset = None
@@ -274,10 +280,14 @@ class PayloadProcessor:
         detections = {}
 
         for field_name in self.models + [self.gt_field]:
+            filter_expression = ~(F("label").is_in(self.excluded_classes))
+
+            if field_name != self.gt_field:
+                filter_expression &= F("confidence") > self.confidence_threshold
 
             filter_view = sequence_view.filter_labels(
                 self.get_field_name(sequence_view, field_name),
-                ~F("label").is_in(self.excluded_classes),
+                filter_expression,
                 only_matches=False,
             )
             


### PR DESCRIPTION
## What?
 
This PR introduces the `confidence_threshold` input argument in the `Payload`-class, so that model fields can optionally be filtered according to this confidence threshold.
 
## Why?
 
When evaluating a model, having the correct confidence threshold setting is important. We ideally want to have one inference field per model in FiftyOne and be able to filter based on confidence thresholds only afterwards, to avoid creating FiftyOne fields for the same model but with varying confidence thresholds. As the Payload is what takes the data from FiftyOne and gives it to a metric/evaluation, I added the optional confidence filtering threshold here, so that evaluations for different confidence thresholds can be conveniently done.
 
## How?
 
The `confidence_threshold` parameter equals 0 by default. That means, by default, every prediction in a model field is included in the Payload. By modifying the parameter to be larger 0, an optional filtering according to this value takes place.

https://github.com/SEA-AI/seametrics/blob/b1454a2888e2a61a6f6ea0fa0e0da2b53a4b29c8/seametrics/payload/processor.py#L33
https://github.com/SEA-AI/seametrics/blob/b1454a2888e2a61a6f6ea0fa0e0da2b53a4b29c8/seametrics/payload/processor.py#L283-L292
 
## Testing
 I tested it by doing various inferences for the same model field, but with varying confidence thresholds (note the confidence thresholds in the name of the W&B runs).

![image](https://github.com/user-attachments/assets/0d79f22f-397a-4bab-9d78-0a91d9c4c863)

As you can see, the number of false positives is correctly decreasing the larger the confidence value gets.
