### PR TITLE
DATA-328: adapt payload so that it can handle ungrouped datasets

### DIFF
--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -170,12 +170,12 @@ class PayloadProcessor:
         """
         self.print_info()
 
-        if self.slices is None:
-            relevant_slices = self.get_datatype_slices()
-        else:
-            relevant_slices = set(self.slices)
+        if self.dataset.media_type == "group":
+            if not self.slices:
+                relevant_slices = self.get_datatype_slices()
+            else:
+                relevant_slices = set(self.slices)
 
-        if relevant_slices is not None:
             self.dataset = self.dataset.select_group_slices(relevant_slices)
 
         if self.tags:
@@ -190,7 +190,7 @@ class PayloadProcessor:
 
         return self.process_sequences()
 
-    def get_datatype_slices(self) -> Union[List[str], None]:
+    def get_datatype_slices(self) -> List[str]:
         """
         Retrieves the relevant slices based on the data type.
 
@@ -199,10 +199,7 @@ class PayloadProcessor:
 
         Raises:
             ValueError: If there is no matching data slice for the data type.
-        """
-        if self.dataset.group_slices is None:
-            return None
-        
+        """        
         thermal_slices = {"thermal_wide", "thermal_narrow", "thermal_right", "thermal_left", "thermal_stitched"}
         rgb_slices = {"rgb", "rgb_wide", "rgb_narrow"}
 

--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -174,7 +174,9 @@ class PayloadProcessor:
             relevant_slices = self.get_datatype_slices()
         else:
             relevant_slices = set(self.slices)
-        self.dataset = self.dataset.select_group_slices(relevant_slices)
+
+        if relevant_slices is not None:
+            self.dataset = self.dataset.select_group_slices(relevant_slices)
 
         if self.tags:
             self.dataset = self.dataset.match_tags(self.tags, all=True)
@@ -198,6 +200,9 @@ class PayloadProcessor:
         Raises:
             ValueError: If there is no matching data slice for the data type.
         """
+        if self.dataset.group_slices is None:
+            return None
+        
         thermal_slices = {"thermal_wide", "thermal_narrow", "thermal_right", "thermal_left", "thermal_stitched"}
         rgb_slices = {"rgb", "rgb_wide", "rgb_narrow"}
 

--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -176,6 +176,8 @@ class PayloadProcessor:
             else:
                 relevant_slices = set(self.slices)
 
+            logger.info(f"Using slice: {relevant_slices}")
+
             self.dataset = self.dataset.select_group_slices(relevant_slices)
 
         if self.tags:
@@ -185,8 +187,6 @@ class PayloadProcessor:
             self.dataset = self.dataset.match(F("sequence").is_in(self.sequence_list))
 
         self.sequence_list = self.dataset.distinct("sequence")
-
-        logger.info(f"Using slice: {relevant_slices}")
 
         return self.process_sequences()
 

--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Literal
+from typing import Dict, List, Literal, Union
 
 import fiftyone as fo
 from fiftyone import ViewField as F
@@ -190,7 +190,7 @@ class PayloadProcessor:
 
         return self.process_sequences()
 
-    def get_datatype_slices(self) -> List[str]:
+    def get_datatype_slices(self) -> Union[List[str], None]:
         """
         Retrieves the relevant slices based on the data type.
 


### PR DESCRIPTION
## What?
 
This PR adapts the payload so that it can handle ungrouped FiftyOne datasets, as using the payload with a ungrouped dataset lead to an error before.
 
## Why?
 
The payload has a smart slice selection, which assumes that slices exist within the given dataset. This is not always true and lead to errors for the new `TEST_THERMAL_ALL_2025_03_IMAGE_BB` dataset.

## How?
 
As a first step now, the smart slice selection checks if the dataset has slices. If not, no slice selection is taking place.
 
## Testing
 
I installed this branch and tested it together with the adapted version of the detection metrics script in ml-ops (PR coming soon..). It worked again without an error.
