### PR TITLE
Det-metrics compatible with confidence-less predictions

### DIFF
--- a/seametrics/detection/cocoeval.py
+++ b/seametrics/detection/cocoeval.py
@@ -618,15 +618,20 @@ class COCOeval:
             iStr = '@[ IoU={:<9} | area={:>9s} | maxDets={:>3d} ] = {}'
             iouStr = '{:0.2f}:{:0.2f}'.format(p.iouThrs[0], p.iouThrs[-1]) \
                 if iouThr is None else '{:0.2f}'.format(iouThr)
-            metrics_str = f"{tp.sum():>6.0f}, {fp.sum():>6.0f}, {fn.sum():>6.0f}, \
-                {dup.sum():>6.0f}, "
-            str_pr, str_rec, str_f1 = pr[pr != -1].mean() \
-                if len(pr[pr != -1]) > 0 else 0, \
-                rec[rec != -1].mean() if len(rec[rec != -1]) > 0 else 0, \
-                f1[f1 != -1].mean() if len(f1[f1 != -1]) > 0 else 0
-            metrics_str += f"{str_pr:>5.2f}, {str_rec:>5.2f}, {str_f1:>5.2f}, \
-                {support.sum():>6.0f}, "
-            metrics_str += f"{fpi.sum():>6.0f}, {nImgs:>6.0f}"
+            if self.params.useCats == 0:
+                metrics_str = f"{tp:>6.0f}, {fp:>6.0f}, {fn:>6.0f}, {dup:>6.0f}, "
+                metrics_str += f"{pr:>5.2f}, {rec:>5.2f}, {f1:>5.2f}, {support:>6.0f}, "
+                metrics_str += f"{fpi:>6.0f}, {nImgs:>6.0f}"
+            else:
+                metrics_str = f"{tp.sum():>6.0f}, {fp.sum():>6.0f}, {fn.sum():>6.0f}, \
+                    {dup.sum():>6.0f}, "
+                str_pr, str_rec, str_f1 = pr[pr != -1].mean() \
+                    if len(pr[pr != -1]) > 0 else 0, \
+                    rec[rec != -1].mean() if len(rec[rec != -1]) > 0 else 0, \
+                    f1[f1 != -1].mean() if len(f1[f1 != -1]) > 0 else 0
+                metrics_str += f"{str_pr:>5.2f}, {str_rec:>5.2f}, {str_f1:>5.2f}, \
+                    {support.sum():>6.0f}, "
+                metrics_str += f"{fpi.sum():>6.0f}, {nImgs:>6.0f}"
             print(iStr.format(iouStr, areaRng, maxDets, metrics_str))
 
             if self.params.useCats != 1:

--- a/seametrics/payload/processor.py
+++ b/seametrics/payload/processor.py
@@ -284,7 +284,7 @@ class PayloadProcessor:
         for field_name in self.models + [self.gt_field]:
             filter_expression = ~(F("label").is_in(self.excluded_classes))
 
-            if field_name != self.gt_field:
+            if self.confidence_threshold > 0 and field_name != self.gt_field:
                 filter_expression &= F("confidence") > self.confidence_threshold
 
             filter_view = sequence_view.filter_labels(


### PR DESCRIPTION
## What?

1. Only add filter-by-confidence when threshold is bigger than 0.
2. Fixed summary formatting when using class agnostic metrics.

## Why

1. Oversea does not provide a confidence value, therefore it is `None` by default and all detections are ignored.
2. Hard to interpret the printed summary

## How

1. Updated the filter expression in `processor.py` to include a check for `confidence_threshold > 0`
2. Added conditional logic in `cocoeval.py` to check `useCats` parameter and handle metrics calculation accordingly

## Testing

Metrics computed with this script.

> [!NOTE]
> W&B polymetrics job was not running for some reason 🥲 

```python
import os
os.environ["FIFTYONE_CONFIG_PATH"] = "/etc/fiftyone/config.json"

from seametrics.payload.processor import PayloadProcessor
from seametrics.fo_utils.utils import fo_upload
import evaluate

config = {
    "payload": {
        "dataset_name": "SENTRY_VIDEOS_QA",
        "slices": ["thermal_wide"],
        "gt_field": "ground_truth_det_fused_id_sensors_json",
        "models": ["sentry_v3_9_0_det"],
        "tracking_mode": True,
    },
    "evaluate": {
        "area_ranges_tuples": [
            ("all", [0, 1e5**2]),
            ("small", [0**2, 6**2]),
            ("medium", [6**2, 12**2]),
            ("large", [12**2, 1e5**2]),
        ],
    },
}

payload = PayloadProcessor(**config["payload"]).payload
module = evaluate.load("SEA-AI/det-metrics")
results = module.compute_from_payload(payload=payload, **config["evaluate"])
fo_upload(
    dataset_name="SENTRY_VIDEOS_QA",
    metrics=results,
    metric_name="SEA-AI/det-metrics",
    description=str(config),
)
```

```bash
... <per sequence results>

##### sentry_v3_9_0_det #####
                                             METRIC     tp,     fp,     fn,    dup,    pr,    re,    f1,   supp,    fpi,  nImgs
@[ IoU=0.00      | area=      all | maxDets=100 ] =  79538,  12820,  31566,   2259,  0.86,  0.72,  0.78, 111104,   1912, 268446
@[ IoU=0.00      | area=    small | maxDets=100 ] =  37100,   8236,  20667,   1621,  0.82,  0.64,  0.72,  57767,   2161, 268446
@[ IoU=0.00      | area=   medium | maxDets=100 ] =  22269,   2702,   4509,    324,  0.89,  0.83,  0.86,  26778,   1564, 268446
@[ IoU=0.00      | area=    large | maxDets=100 ] =  21976,   2113,   4637,    545,  0.91,  0.83,  0.87,  26613,   1389, 268446
```