### PR TITLE
SEA-406: implement HOTA metrics and fix TrackingMetrics bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,55 @@ Where:
 - `nImgs` is the number of images
 
 </details>
+
+<details>
+<summary>Tracking Metrics</summary>
+
+## Tracking Metrics
+
+`TrackingMetrics` wraps [motmetrics](https://github.com/cheind/py-motmetrics) to compute standard MOT scores (MOTA, MOTP, IDF1, …). `HOTAMetrics` implements [HOTA](https://link.springer.com/article/10.1007/s11263-020-01375-2) (Higher Order Tracking Accuracy), which jointly evaluates detection and association quality.
+
+Both classes share the same interface and can be evaluated together in a single dataset pass using `compute_all_metrics_by_sequence`.
+
+```python
+import fiftyone as fo
+from seametrics.tracking import TrackingMetrics, HOTAMetrics
+from seametrics.tracking.utils import compute_all_metrics_by_sequence, results_to_df
+
+dataset = fo.load_dataset("my_dataset")
+view = dataset.load_saved_view("my_view")
+
+results = compute_all_metrics_by_sequence(
+    view=view,
+    gt_field="ground_truth",
+    pred_fields=["model_a", "model_b"],
+    metrics=[
+        (TrackingMetrics, {"max_iou": 0.5}),
+        (HOTAMetrics, {}),
+    ],
+)
+```
+
+Returns a nested dict `{pred_field: {metric_class_name: metric_instance}}`. Convert any entry to a per-sequence DataFrame with `results_to_df`:
+
+```python
+mot_df  = results_to_df(results["model_a"]["TrackingMetrics"])
+hota_df = results_to_df(results["model_a"]["HOTAMetrics"])
+```
+
+`TrackingMetrics` DataFrame columns: `sequence`, `num_frames`, `num_unique_objects`, `mota`, `motp`, `idf1`, `idp`, `idr`, `mostly_tracked`, `partially_tracked`, `mostly_lost`, `num_switches`, `num_false_positives`, `num_misses`, `num_fragmentations`, `precision`, `recall`.
+
+`HOTAMetrics` DataFrame columns: `sequence`, `hota`, `deta`, `assa`, `loca`, `num_unique_objects`. Scores are expressed as percentages (0–100).
+
+`num_unique_objects` is included in both DataFrames so you can compute a track-count-weighted global score:
+
+```python
+weighted_hota = (
+    (hota_df["hota"] * hota_df["num_unique_objects"]).sum()
+    / hota_df["num_unique_objects"].sum()
+)
+```
+
+Failed sequences (empty GT, empty predictions, or unexpected errors) are logged rather than raising, and are accessible via `metric_instance.failed_sequences`.
+
+</details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "tqdm>=4.64.0",
   "typing_extensions>=4.7.0",
   "motmetrics>=1.4.0",
+  "scipy>=1.7.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ['version']
 authors = [{ name = "Kevin Serrano" }, { name = "Vasco Rodrigues" }]
 description = "Custom metrics for evaluating performance of A.I. pipelines at SEA.AI"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",

--- a/seametrics/tracking/__init__.py
+++ b/seametrics/tracking/__init__.py
@@ -1,3 +1,4 @@
 from .imports import _MOTMETRICS_AVAILABLE
 
 from .track import TrackingMetrics
+from .hota import HOTAMetrics

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -34,7 +34,12 @@ def _hungarian_match(iou_mat: np.ndarray, threshold: float):
     if M == 0 or N == 0:
         return [], list(range(M)), list(range(N))
 
-    row_ind, col_ind = linear_sum_assignment(-iou_mat)
+    # Prioritise maximising the count of valid (iou >= threshold) matches first,
+    # then use IoU as a tie-breaker. A valid pair always beats any invalid pair
+    # because the validity bonus (2.0) exceeds the maximum possible IoU (1.0).
+    valid = (iou_mat >= threshold).astype(float)
+    cost_mat = -(2.0 * valid + iou_mat)
+    row_ind, col_ind = linear_sum_assignment(cost_mat)
 
     matched_gt, matched_pr = set(), set()
     matches = []
@@ -110,15 +115,18 @@ class HOTAMetrics:
         gt, pred = self.accumulators[sequence]
         return self._compute_hota(gt, pred)
 
-    def log_failed_sequence(self, sequence_name: str, gt, pred) -> None:
+    def log_failed_sequence(self, sequence_name: str, gt, pred, exc: Exception = None) -> None:
         if len(gt) == 0 and len(pred) == 0:
-            self.failed_sequences[sequence_name] = "No ground truth and no predictions"
+            reason = "No ground truth and no predictions"
         elif len(gt) == 0:
-            self.failed_sequences[sequence_name] = "No ground truth"
+            reason = "No ground truth"
         elif len(pred) == 0:
-            self.failed_sequences[sequence_name] = "No predictions"
+            reason = "No predictions"
+        elif exc is not None:
+            reason = f"{type(exc).__name__}: {exc}"
         else:
-            self.failed_sequences[sequence_name] = "Missing IDs from GT or Pred"
+            reason = "Unknown error"
+        self.failed_sequences[sequence_name] = reason
 
     # ------------------------------------------------------------------
     # Core computation
@@ -138,6 +146,8 @@ class HOTAMetrics:
             frames.update(pred[:, 0].astype(int).tolist())
 
         frame_cache = []
+        gt_track_frames: dict = defaultdict(int)
+        pred_track_frames: dict = defaultdict(int)
         for frame in sorted(frames):
             gt_f = gt[gt[:, 0] == frame] if len(gt) > 0 else np.empty((0, 7))
             pr_f = pred[pred[:, 0] == frame] if len(pred) > 0 else np.empty((0, 7))
@@ -147,6 +157,10 @@ class HOTAMetrics:
             pr_boxes = pr_f[:, 2:6] if len(pr_f) > 0 else np.empty((0, 4))
             iou_mat = _iou_matrix(gt_boxes, pr_boxes)
             frame_cache.append((gt_ids, pr_ids, iou_mat))
+            for g in gt_ids:
+                gt_track_frames[g] += 1
+            for p in pr_ids:
+                pred_track_frames[p] += 1
 
         hota_vals, deta_vals, assa_vals, loca_vals = [], [], [], []
 
@@ -180,15 +194,13 @@ class HOTAMetrics:
                 assa, loca = 0.0, 0.0
             else:
                 pair_counts: dict = defaultdict(int)
-                gt_counts: dict = defaultdict(int)
-                pr_counts: dict = defaultdict(int)
                 for g, p, _ in tp_list:
                     pair_counts[(g, p)] += 1
-                    gt_counts[g] += 1
-                    pr_counts[p] += 1
 
                 ass_sum = sum(
-                    pair_counts[(g, p)] / (gt_counts[g] + pr_counts[p] - pair_counts[(g, p)])
+                    pair_counts[(g, p)] / (
+                        gt_track_frames[g] + pred_track_frames[p] - pair_counts[(g, p)]
+                    )
                     for g, p, _ in tp_list
                 )
                 assa = ass_sum / n_tp

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -1,5 +1,6 @@
 import numpy as np
 from collections import defaultdict
+from scipy.optimize import linear_sum_assignment
 
 _HOTA_THRESHOLDS = np.arange(0.05, 0.95 + 1e-9, 0.05)  # 19 values: 0.05 … 0.95
 
@@ -22,29 +23,27 @@ def _iou_matrix(gt_boxes: np.ndarray, pred_boxes: np.ndarray) -> np.ndarray:
     return np.where(union > 0, inter / union, 0.0).astype(np.float32)
 
 
-def _greedy_match(iou_mat: np.ndarray, threshold: float):
+def _hungarian_match(iou_mat: np.ndarray, threshold: float):
     """
-    Greedy matching by descending IoU.
+    Optimal one-to-one matching via the Hungarian algorithm.
     Returns (matches, unmatched_gt_indices, unmatched_pred_indices).
     matches is a list of (gt_idx, pred_idx, iou).
+    Pairs whose IoU is below threshold are discarded.
     """
     M, N = iou_mat.shape
     if M == 0 or N == 0:
         return [], list(range(M)), list(range(N))
 
-    order = np.argsort(-iou_mat.ravel())
+    row_ind, col_ind = linear_sum_assignment(-iou_mat)
+
     matched_gt, matched_pr = set(), set()
     matches = []
-
-    for flat_idx in order:
-        iou = iou_mat.ravel()[flat_idx]
-        if iou < threshold:
-            break
-        i, j = divmod(int(flat_idx), N)
-        if i not in matched_gt and j not in matched_pr:
-            matches.append((i, j, float(iou)))
-            matched_gt.add(i)
-            matched_pr.add(j)
+    for r, c in zip(row_ind, col_ind):
+        iou = float(iou_mat[r, c])
+        if iou >= threshold:
+            matches.append((int(r), int(c), iou))
+            matched_gt.add(int(r))
+            matched_pr.add(int(c))
 
     unmatched_gt = [i for i in range(M) if i not in matched_gt]
     unmatched_pr = [j for j in range(N) if j not in matched_pr]
@@ -167,7 +166,7 @@ class HOTAMetrics:
                     n_fn += n_gt
                     continue
 
-                matches, unmatched_gt, unmatched_pr = _greedy_match(iou_mat, alpha)
+                matches, unmatched_gt, unmatched_pr = _hungarian_match(iou_mat, alpha)
                 for gi, pi, iou in matches:
                     tp_list.append((gt_ids[gi], pr_ids[pi], iou))
                 n_fp += len(unmatched_pr)

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -1,0 +1,208 @@
+import numpy as np
+from collections import defaultdict
+
+_HOTA_THRESHOLDS = np.arange(0.05, 0.95 + 1e-9, 0.05)  # 19 values: 0.05 … 0.95
+
+
+def _iou_matrix(gt_boxes: np.ndarray, pred_boxes: np.ndarray) -> np.ndarray:
+    """Vectorised IoU between every (gt, pred) pair. Both arrays are (N, 4) xyxy."""
+    if len(gt_boxes) == 0 or len(pred_boxes) == 0:
+        return np.zeros((len(gt_boxes), len(pred_boxes)), dtype=np.float32)
+
+    gt = gt_boxes[:, None, :]    # (M, 1, 4)
+    pr = pred_boxes[None, :, :]  # (1, N, 4)
+
+    inter = (
+        np.maximum(0, np.minimum(gt[..., 2], pr[..., 2]) - np.maximum(gt[..., 0], pr[..., 0]))
+        * np.maximum(0, np.minimum(gt[..., 3], pr[..., 3]) - np.maximum(gt[..., 1], pr[..., 1]))
+    )
+    area_gt = (gt_boxes[:, 2] - gt_boxes[:, 0]) * (gt_boxes[:, 3] - gt_boxes[:, 1])
+    area_pr = (pred_boxes[:, 2] - pred_boxes[:, 0]) * (pred_boxes[:, 3] - pred_boxes[:, 1])
+    union = area_gt[:, None] + area_pr[None, :] - inter
+    return np.where(union > 0, inter / union, 0.0).astype(np.float32)
+
+
+def _greedy_match(iou_mat: np.ndarray, threshold: float):
+    """
+    Greedy matching by descending IoU.
+    Returns (matches, unmatched_gt_indices, unmatched_pred_indices).
+    matches is a list of (gt_idx, pred_idx, iou).
+    """
+    M, N = iou_mat.shape
+    if M == 0 or N == 0:
+        return [], list(range(M)), list(range(N))
+
+    order = np.argsort(-iou_mat.ravel())
+    matched_gt, matched_pr = set(), set()
+    matches = []
+
+    for flat_idx in order:
+        iou = iou_mat.ravel()[flat_idx]
+        if iou < threshold:
+            break
+        i, j = divmod(int(flat_idx), N)
+        if i not in matched_gt and j not in matched_pr:
+            matches.append((i, j, float(iou)))
+            matched_gt.add(i)
+            matched_pr.add(j)
+
+    unmatched_gt = [i for i in range(M) if i not in matched_gt]
+    unmatched_pr = [j for j in range(N) if j not in matched_pr]
+    return matches, unmatched_gt, unmatched_pr
+
+
+class HOTAMetrics:
+    """
+    HOTA (Higher Order Tracking Accuracy).
+
+    Reference: Luiten et al., "HOTA: A Higher Order Metric for Evaluating
+    Multi-Object Tracking", IJCV 2021.
+
+    Interface mirrors TrackingMetrics so it can be used as a drop-in with
+    compute_metrics_by_sequence / hota_results_to_df.
+
+    Input arrays follow the same MOT format used by TrackingMetrics:
+        [frame_id, obj_id, x1, y1, x2, y2, confidence, ...]
+    """
+
+    def __init__(self, **kwargs) -> None:
+        self.accumulators: dict = {}   # sequence_name -> (gt_array, pred_array)
+        self.iou_thresholds: np.ndarray = _HOTA_THRESHOLDS
+        self.failed_sequences: dict = {}
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def update(self, gt: np.ndarray, pred: np.ndarray, sequence_name: str) -> None:
+        self.accumulators[sequence_name] = (gt, pred)
+
+    def compute(self, sequence: str = None) -> dict:
+        """
+        Compute HOTA metrics.
+
+        Parameters
+        ----------
+        sequence:
+            Sequence name to compute metrics for. If None, averages over all
+            stored sequences (standard MOT benchmark convention).
+
+        Returns
+        -------
+        dict with keys: hota, deta, assa, loca  (values in [0, 1])
+        """
+        if sequence is None:
+            per_seq = [
+                self._compute_hota(gt, pred)
+                for gt, pred in self.accumulators.values()
+            ]
+            if not per_seq:
+                return {}
+            keys = per_seq[0].keys()
+            return {
+                k: float(np.nanmean([r[k] for r in per_seq]))
+                for k in keys
+            }
+
+        if sequence not in self.accumulators:
+            raise KeyError(f"Unknown sequence: {sequence}")
+        gt, pred = self.accumulators[sequence]
+        return self._compute_hota(gt, pred)
+
+    def log_failed_sequence(self, sequence_name: str, gt, pred) -> None:
+        if len(gt) == 0 and len(pred) == 0:
+            self.failed_sequences[sequence_name] = "No ground truth and no predictions"
+        elif len(gt) == 0:
+            self.failed_sequences[sequence_name] = "No ground truth"
+        elif len(pred) == 0:
+            self.failed_sequences[sequence_name] = "No predictions"
+        else:
+            self.failed_sequences[sequence_name] = "Missing IDs from GT or Pred"
+
+    # ------------------------------------------------------------------
+    # Core computation
+    # ------------------------------------------------------------------
+
+    def _compute_hota(self, gt: np.ndarray, pred: np.ndarray) -> dict:
+        nan_result = {k: float("nan") for k in ["hota", "deta", "assa", "loca"]}
+
+        if len(gt) == 0 and len(pred) == 0:
+            return nan_result
+
+        # Pre-compute IoU matrices once per frame (reused across all thresholds)
+        frames = set()
+        if len(gt) > 0:
+            frames.update(gt[:, 0].astype(int).tolist())
+        if len(pred) > 0:
+            frames.update(pred[:, 0].astype(int).tolist())
+
+        frame_cache = []
+        for frame in sorted(frames):
+            gt_f = gt[gt[:, 0] == frame] if len(gt) > 0 else np.empty((0, 7))
+            pr_f = pred[pred[:, 0] == frame] if len(pred) > 0 else np.empty((0, 7))
+            gt_ids = gt_f[:, 1].astype(int).tolist()
+            pr_ids = pr_f[:, 1].astype(int).tolist()
+            gt_boxes = gt_f[:, 2:6] if len(gt_f) > 0 else np.empty((0, 4))
+            pr_boxes = pr_f[:, 2:6] if len(pr_f) > 0 else np.empty((0, 4))
+            iou_mat = _iou_matrix(gt_boxes, pr_boxes)
+            frame_cache.append((gt_ids, pr_ids, iou_mat))
+
+        hota_vals, deta_vals, assa_vals, loca_vals = [], [], [], []
+
+        for alpha in self.iou_thresholds:
+            tp_list = []   # (gt_id, pred_id, iou)
+            n_fp = 0
+            n_fn = 0
+
+            for gt_ids, pr_ids, iou_mat in frame_cache:
+                n_gt, n_pr = len(gt_ids), len(pr_ids)
+                if n_gt == 0 and n_pr == 0:
+                    continue
+                if n_gt == 0:
+                    n_fp += n_pr
+                    continue
+                if n_pr == 0:
+                    n_fn += n_gt
+                    continue
+
+                matches, unmatched_gt, unmatched_pr = _greedy_match(iou_mat, alpha)
+                for gi, pi, iou in matches:
+                    tp_list.append((gt_ids[gi], pr_ids[pi], iou))
+                n_fp += len(unmatched_pr)
+                n_fn += len(unmatched_gt)
+
+            n_tp = len(tp_list)
+            total = n_tp + n_fp + n_fn
+            deta = n_tp / total if total > 0 else 0.0
+
+            if n_tp == 0:
+                assa, loca = 0.0, 0.0
+            else:
+                pair_counts: dict = defaultdict(int)
+                gt_counts: dict = defaultdict(int)
+                pr_counts: dict = defaultdict(int)
+                for g, p, _ in tp_list:
+                    pair_counts[(g, p)] += 1
+                    gt_counts[g] += 1
+                    pr_counts[p] += 1
+
+                ass_sum = sum(
+                    pair_counts[(g, p)] / (gt_counts[g] + pr_counts[p] - pair_counts[(g, p)])
+                    for g, p, _ in tp_list
+                )
+                assa = ass_sum / n_tp
+                loca = sum(iou for _, _, iou in tp_list) / n_tp
+
+            hota_vals.append((deta * assa) ** 0.5)
+            deta_vals.append(deta)
+            assa_vals.append(assa)
+            loca_vals.append(loca)
+
+        return {
+            "hota": float(np.mean(hota_vals)),
+            "deta": float(np.mean(deta_vals)),
+            "assa": float(np.mean(assa_vals)),
+            "loca": float(np.mean(loca_vals)),
+        }

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -96,17 +96,41 @@ class HOTAMetrics:
         Returns
         -------
         dict with keys: hota, deta, assa, loca  (values in [0, 1]) and
-        num_unique_objects (integer count of distinct GT track IDs)
+        num_unique_objects (integer count of distinct GT track IDs).
+        When sequence is None, TP/FP/FN/association counts are pooled across
+        all sequences before computing metrics (MOT standard).
         """
         if sequence is None:
             entries = list(self.accumulators.values())
             if not entries:
                 return {}
-            per_seq = [self._compute_hota(gt, pred) for gt, pred in entries]
-            keys = [k for k in per_seq[0].keys() if k != "num_unique_objects"]
-            result = {k: float(np.nanmean([r[k] for r in per_seq])) for k in keys}
-            result["num_unique_objects"] = sum(r["num_unique_objects"] for r in per_seq)
-            return result
+            # Pool raw arrays across sequences so counts are aggregated before
+            # computing metrics (MOT standard), rather than averaging per-sequence
+            # results which biases toward sequences with fewer objects.
+            # Frame and track IDs are offset per sequence to prevent collisions.
+            gt_parts, pred_parts = [], []
+            frame_off = gt_off = pred_off = 0
+            for gt, pred in entries:
+                max_frame = max(
+                    int(gt[:, 0].max()) if len(gt) > 0 else 0,
+                    int(pred[:, 0].max()) if len(pred) > 0 else 0,
+                )
+                if len(gt) > 0:
+                    g = gt.copy()
+                    g[:, 0] += frame_off
+                    g[:, 1] += gt_off
+                    gt_parts.append(g)
+                    gt_off += int(gt[:, 1].max()) + 1
+                if len(pred) > 0:
+                    p = pred.copy()
+                    p[:, 0] += frame_off
+                    p[:, 1] += pred_off
+                    pred_parts.append(p)
+                    pred_off += int(pred[:, 1].max()) + 1
+                frame_off += max_frame + 1
+            pooled_gt = np.concatenate(gt_parts) if gt_parts else np.empty((0,), dtype=float)
+            pooled_pred = np.concatenate(pred_parts) if pred_parts else np.empty((0,), dtype=float)
+            return self._compute_hota(pooled_gt, pooled_pred)
 
         if sequence not in self.accumulators:
             raise KeyError(f"Unknown sequence: {sequence}")

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -95,20 +95,18 @@ class HOTAMetrics:
 
         Returns
         -------
-        dict with keys: hota, deta, assa, loca  (values in [0, 1])
+        dict with keys: hota, deta, assa, loca  (values in [0, 1]) and
+        num_unique_objects (integer count of distinct GT track IDs)
         """
         if sequence is None:
-            per_seq = [
-                self._compute_hota(gt, pred)
-                for gt, pred in self.accumulators.values()
-            ]
-            if not per_seq:
+            entries = list(self.accumulators.values())
+            if not entries:
                 return {}
-            keys = per_seq[0].keys()
-            return {
-                k: float(np.nanmean([r[k] for r in per_seq]))
-                for k in keys
-            }
+            per_seq = [self._compute_hota(gt, pred) for gt, pred in entries]
+            keys = [k for k in per_seq[0].keys() if k != "num_unique_objects"]
+            result = {k: float(np.nanmean([r[k] for r in per_seq])) for k in keys}
+            result["num_unique_objects"] = sum(r["num_unique_objects"] for r in per_seq)
+            return result
 
         if sequence not in self.accumulators:
             raise KeyError(f"Unknown sequence: {sequence}")
@@ -133,7 +131,9 @@ class HOTAMetrics:
     # ------------------------------------------------------------------
 
     def _compute_hota(self, gt: np.ndarray, pred: np.ndarray) -> dict:
+        num_unique_objects = int(len(np.unique(gt[:, 1]))) if len(gt) > 0 else 0
         nan_result = {k: float("nan") for k in ["hota", "deta", "assa", "loca"]}
+        nan_result["num_unique_objects"] = num_unique_objects
 
         if len(gt) == 0 and len(pred) == 0:
             return nan_result
@@ -216,4 +216,5 @@ class HOTAMetrics:
             "deta": float(np.mean(deta_vals)),
             "assa": float(np.mean(assa_vals)),
             "loca": float(np.mean(loca_vals)),
+            "num_unique_objects": num_unique_objects,
         }

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -125,7 +125,7 @@ class HOTAMetrics:
         elif exc is not None:
             reason = f"{type(exc).__name__}: {exc}"
         else:
-            reason = "Unknown error"
+            reason = "Missing IDs from GT or Pred"
         self.failed_sequences[sequence_name] = reason
 
     # ------------------------------------------------------------------

--- a/seametrics/tracking/imports.py
+++ b/seametrics/tracking/imports.py
@@ -1,5 +1,10 @@
 import sys
 from importlib.util import find_spec
+import numpy as np
+
+# motmetrics uses np.asfarray which was removed in NumPy 2.0
+if not hasattr(np, "asfarray"):
+    np.asfarray = lambda a, dtype=float: np.asarray(a, dtype=dtype)
 
 def package_available(package_name: str) -> bool:
     """Check if a package is available in your environment.

--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -27,12 +27,16 @@ class TrackingMetrics:
 
     def compute(self, sequence: str = None) -> dict:
         mh = mm.metrics.create()
-        if sequence not in self.accumulators:
-            raise Exception(f'Unknown sequence: {sequence}')
-
         if sequence is None:
-            summary = mh.compute_many(self.accumulators.values(), metrics=self.metrics, names=self.accumulators.keys(), generate_overall=True)
+            summary = mh.compute_many(
+                list(self.accumulators.values()),
+                metrics=self.metrics,
+                names=list(self.accumulators.keys()),
+                generate_overall=True,
+            )
         else:
+            if sequence not in self.accumulators:
+                raise Exception(f'Unknown sequence: {sequence}')
             summary = mh.compute(self.accumulators[sequence], metrics=self.metrics)
 
         return summary.to_dict()

--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -40,15 +40,18 @@ class TrackingMetrics:
             summary = mh.compute(self.accumulators[sequence], metrics=self.metrics)
 
         return summary.to_dict()
-    def log_failed_sequence(self, sequence_name: str, gt: list, pred: list) -> None:
+    def log_failed_sequence(self, sequence_name: str, gt: list, pred: list, exc: Exception = None) -> None:
         if len(gt) == 0 and len(pred) == 0:
-            self.failed_sequences[sequence_name] = "No ground truth and no predictions"
+            reason = "No ground truth and no predictions"
         elif len(gt) == 0:
-            self.failed_sequences[sequence_name] = "No ground truth"
+            reason = "No ground truth"
         elif len(pred) == 0:
-            self.failed_sequences[sequence_name] = "No predictions"
+            reason = "No predictions"
+        elif exc is not None:
+            reason = f"{type(exc).__name__}: {exc}"
         else:
-            self.failed_sequences[sequence_name] = "Missing IDs from GT or Pred"
+            reason = "Unknown error"
+        self.failed_sequences[sequence_name] = reason
 
     def metrics_help(self): 
         print(mm.metrics.create().list_metrics_markdown())

--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -50,7 +50,7 @@ class TrackingMetrics:
         elif exc is not None:
             reason = f"{type(exc).__name__}: {exc}"
         else:
-            reason = "Unknown error"
+            reason = "Missing IDs from GT or Pred"
         self.failed_sequences[sequence_name] = reason
 
     def metrics_help(self): 

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -163,11 +163,12 @@ def get_values(view: fo.DatasetView,
     else:
         raise ValueError(f"Unsupported media type: {view.media_type}")
 
-def compute_metrics(view: fo.DatasetView, # view
-                    gt_field: str,  # fiftyone field name
-                    pred_field: str  # fiftyone field name
-                    ):
-    """Computes metrics for a given sequence view."""
+def build_detection_inputs(
+    view: fo.DatasetView,
+    gt_field: str,
+    pred_field: str,
+):
+    """Returns (target, preds) numpy arrays for the given sequence view."""
 
     view = get_relevant_fields(view, [gt_field, pred_field])
 
@@ -206,6 +207,19 @@ def compute_metrics(view: fo.DatasetView, # view
     del dt_bboxes_per_frame, dt_scores_per_frame, dt_track_ids_per_frame
 
     return target, preds
+
+def compute_metrics(
+    view: fo.DatasetView,
+    gt_field: str,
+    pred_field: str,
+    metric_fn: callable,
+    metric_kwargs: dict,
+):
+    """Computes metrics for a given sequence view. Returns the metric.compute() dict."""
+    target, preds = build_detection_inputs(view, gt_field, pred_field)
+    metric = metric_fn(**metric_kwargs)
+    metric.update(preds, target)
+    return metric.compute()
 
 def sequence_results_to_df(sequence_results):
     # save to pandas dataframe
@@ -268,6 +282,8 @@ def compute_and_save_sequence_metrics(
                 view=sequence_view,
                 gt_field=gt_field,
                 pred_field=pred_field,
+                metric_fn=metric_fn,
+                metric_kwargs=metric_kwargs,
             )
 
         if debug:
@@ -295,7 +311,7 @@ def compute_metrics_by_sequence(
         sequence_list = get_relevant_fields(view, [gt_field, pred_field, 'sequence']).distinct("sequence")
     for sequence_name in sequence_list:
         sequence_view = view.match(F("sequence") == sequence_name)
-        sequence_results[sequence_name] = compute_metrics(
+        sequence_results[sequence_name] = build_detection_inputs(
             view=sequence_view,
             gt_field=gt_field,
             pred_field=pred_field
@@ -303,8 +319,10 @@ def compute_metrics_by_sequence(
     for sequence in sequence_results.keys():
         try:
             metric.update(sequence_results[sequence][0], sequence_results[sequence][1], sequence)
-        except Exception as e:
-            metric.log_failed_sequence(sequence, sequence_results[sequence][0], sequence_results[sequence][1])
+        except (ValueError, IndexError) as e:
+            metric.log_failed_sequence(sequence, sequence_results[sequence][0], sequence_results[sequence][1], exc=e)
+        except Exception:
+            raise
 
     return metric
 
@@ -364,14 +382,16 @@ def compute_all_metrics_by_sequence(
     for sequence_name in sequence_list:
         sequence_view = view.match(F("sequence") == sequence_name)
         for pred_field in pred_fields:
-            gt, pred = compute_metrics(
+            gt, pred = build_detection_inputs(
                 view=sequence_view, gt_field=gt_field, pred_field=pred_field
             )
             for instance in instances[pred_field].values():
                 try:
                     instance.update(gt, pred, sequence_name)
-                except Exception as e:
+                except (ValueError, IndexError) as e:
                     instance.log_failed_sequence(sequence_name, gt, pred, exc=e)
+                except Exception:
+                    raise
 
     return instances
 

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -6,8 +6,6 @@ import numpy as np
 import pandas as pd
 import fiftyone as fo
 from fiftyone import ViewField as F
-from tracking import TrackingMetrics
-
 # helper functions
 
 def prepare_data_for_det_metrics(gt_bboxes_per_frame,
@@ -131,6 +129,9 @@ def get_relevant_fields(view: fo.DatasetView,
     fo.DatasetView
         Dataset view with only the relevant fields.
     """
+
+    if view.media_type == 'group':
+        view = view.select_group_slices(view.default_group_slice)
 
     if view.media_type == 'video':
         return view.select_fields([f"frames.{f}" if view.has_frame_field(f) else f

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -164,10 +164,15 @@ def get_values(view: fo.DatasetView,
 def compute_metrics(view: fo.DatasetView, # view
                     gt_field: str,  # fiftyone field name
                     pred_field: str  # fiftyone field name
-                    ):  
+                    ):
     """Computes metrics for a given sequence view."""
-    
+
     view = get_relevant_fields(view, [gt_field, pred_field, "mux"])
+
+    sample = view.first()
+    img_w = sample["metadata"]["frame_width"]
+    img_h = sample["metadata"]["frame_height"]
+
     gt_bboxes_per_frame = get_values(view,
                                      f"{gt_field}.detections.bounding_box")
     gt_track_ids_per_frame = get_values(view,
@@ -179,7 +184,6 @@ def compute_metrics(view: fo.DatasetView, # view
     dt_track_ids_per_frame = get_values(view,
                                      f"{pred_field}.detections.index")
     mux = get_values(view, "mux")
-    
 
     gt_bboxes_per_frame = [bboxes for (mux_item,bboxes) in zip(mux, gt_bboxes_per_frame) if mux_item]
     gt_track_ids_per_frame = [track_ids for (mux_item, track_ids)  in zip(mux, gt_track_ids_per_frame) if mux_item]
@@ -189,7 +193,8 @@ def compute_metrics(view: fo.DatasetView, # view
 
     target, preds = prepare_data_for_det_metrics(
         gt_bboxes_per_frame, gt_track_ids_per_frame,
-        dt_bboxes_per_frame, dt_track_ids_per_frame,  dt_scores_per_frame)
+        dt_bboxes_per_frame, dt_track_ids_per_frame, dt_scores_per_frame,
+        img_w=img_w, img_h=img_h)
 
     # free memory
     del gt_bboxes_per_frame, gt_track_ids_per_frame, mux
@@ -275,18 +280,17 @@ def compute_metrics_by_sequence(
     view: fo.DatasetView,
     gt_field: str,  # fiftyone field name
     pred_field: str,  # fiftyone field name
-    metric_fn: callable,  # torchmetrics metric
+    metric_fn: callable,  # metric class
     metric_kwargs: dict,  # kwargs for metric_fn
-    sequence_list: list = [], # list of sequence names
+    sequence_list: list = [],  # list of sequence names
     ):
 
     sequence_results = {}
-    
+
     metric = metric_fn(**metric_kwargs)
     if sequence_list is None:
         sequence_list = get_relevant_fields(view, [gt_field, pred_field, 'sequence']).distinct("sequence")
     for sequence_name in sequence_list:
-
         sequence_view = view.match(F("sequence") == sequence_name)
         sequence_results[sequence_name] = compute_metrics(
             view=sequence_view,
@@ -301,13 +305,52 @@ def compute_metrics_by_sequence(
 
     return metric
 
+
+def compute_all_metrics_by_sequence(
+    view: fo.DatasetView,
+    gt_field: str,
+    pred_field: str,
+    metrics: list,  # list of (metric_fn, metric_kwargs) tuples
+    sequence_list: list = None,
+) -> dict:
+    """Run multiple metrics in a single pass over the FiftyOne dataset.
+
+    Parameters
+    ----------
+    metrics:
+        List of (metric_fn, metric_kwargs) tuples, e.g.:
+        [(TrackingMetrics, {"max_iou": 0.5}), (HOTAMetrics, {})]
+
+    Returns
+    -------
+    dict mapping each metric class name to its populated metric instance,
+    e.g. {"TrackingMetrics": <TrackingMetrics>, "HOTAMetrics": <HOTAMetrics>}
+    """
+    if sequence_list is None:
+        sequence_list = get_relevant_fields(view, [gt_field, pred_field, 'sequence']).distinct("sequence")
+
+    instances = {fn.__name__: fn(**kwargs) for fn, kwargs in metrics}
+
+    for sequence_name in sequence_list:
+        sequence_view = view.match(F("sequence") == sequence_name)
+        gt, pred = compute_metrics(view=sequence_view, gt_field=gt_field, pred_field=pred_field)
+
+        for instance in instances.values():
+            try:
+                instance.update(gt, pred, sequence_name)
+            except Exception:
+                instance.log_failed_sequence(sequence_name, gt, pred)
+
+    return instances
+
 def compute_sizes(view: fo.DatasetView,
-                    gt_field: str,  # fiftyone field name
-                    img_w: int = 640,
-                    img_h: int = 512):
+                    gt_field: str):  # fiftyone field name
         """Computes sizes for a given sequence view."""
-        
+
         view = get_relevant_fields(view, [gt_field, "mux"])
+        sample = view.first()
+        img_w = sample["metadata"]["frame_width"]
+        img_h = sample["metadata"]["frame_height"]
         gt_bboxes_per_frame = get_values(view,
                                          f"{gt_field}.detections.bounding_box")
         gt_track_ids_per_frame = get_values(view,
@@ -501,19 +544,40 @@ def _box_xyxy_to_cxcywh(boxes):
     return converted_boxes
 
 def results_to_df(metrics, sequence_list: list = None) -> pd.DataFrame:
-    # if sequence_list is not provided, compute for all sequences
-    df = pd.DataFrame()
+    """Convert TrackingMetrics or HOTAMetrics results to a DataFrame.
+
+    Detects the metric type from the result keys and applies the appropriate
+    scaling so all values are expressed as percentages (0–100).
+
+    TrackingMetrics: MOTA scaled ×100, MOTP converted to (1-MOTP)×100.
+    HOTAMetrics: HOTA/DetA/AssA/LocA scaled ×100.
+    """
     if sequence_list is None:
-        sequence_list = metrics.accumulators.keys()
+        sequence_list = list(metrics.accumulators.keys())
+
+    rows = []
     for sequence in sequence_list:
-        summary = metrics.compute(sequence=sequence)
-        row = pd.DataFrame(summary)
-        row['sequence'] = sequence
-        df = pd.concat([df, row])
-    # df.set_index('sequence', inplace=True)
-    df['mota'] = df['mota']*100
-    df['motp'] = (1-df['motp'])*100
-    return df
+        result = metrics.compute(sequence=sequence)
+
+        if "hota" in result:
+            # HOTAMetrics: result is {metric: float}
+            row = {k: v * 100 for k, v in result.items()}
+        else:
+            # TrackingMetrics: result is {metric: {0: value}} (pandas to_dict format)
+            row = {k: list(v.values())[0] for k, v in result.items()}
+            row["mota"] = row["mota"] * 100
+            row["motp"] = (1 - row["motp"]) * 100
+
+        row["sequence"] = sequence
+        rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+def hota_results_to_df(metrics, sequence_list: list = None) -> pd.DataFrame:
+    """Alias for results_to_df for backward compatibility."""
+    return results_to_df(metrics, sequence_list)
+
 
 def classify_num_objects(x):
     n_objects_ranges_tuples = [

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -349,7 +349,13 @@ def compute_all_metrics_by_sequence(
             view, [gt_field, *pred_fields, "sequence"]
         ).distinct("sequence")
 
-    # Instantiate one set of metric objects per pred_field
+    metric_names = [fn.__name__ for fn, _ in metrics]
+    if len(metric_names) != len(set(metric_names)):
+        raise ValueError(
+            f"Duplicate metric class names in metrics list: {metric_names}. "
+            "Each metric class may only appear once."
+        )
+
     instances = {
         pred_field: {fn.__name__: fn(**kwargs) for fn, kwargs in metrics}
         for pred_field in pred_fields

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -172,6 +172,8 @@ def compute_metrics(view: fo.DatasetView, # view
     view = get_relevant_fields(view, [gt_field, pred_field])
 
     sample = view.first()
+    if sample is None:
+        raise ValueError("View is empty — no samples found after field selection.")
     img_w = sample["metadata"]["frame_width"]
     img_h = sample["metadata"]["frame_height"]
 
@@ -373,6 +375,8 @@ def compute_sizes(view: fo.DatasetView,
 
         view = get_relevant_fields(view, [gt_field])
         sample = view.first()
+        if sample is None:
+            raise ValueError("View is empty — no samples found after field selection.")
         img_w = sample["metadata"]["frame_width"]
         img_h = sample["metadata"]["frame_height"]
         gt_bboxes_per_frame = get_values(view,

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -26,7 +26,7 @@ def prepare_data_for_det_metrics(gt_bboxes_per_frame,
 
     def _to_tracker_format(gt_bboxes_per_frame, gt_track_ids_per_frame,
                       dt_bboxes_per_frame, dt_track_ids_per_frame, dt_scores_per_frame,
-                      img_w: int = 640, img_h: int = 512):
+                      img_w: int, img_h: int):
         """Converts a list of frames with detections (bboxes) to numpy format."""
 
         # Tracker format <frame number>, <object id>, <bb_left>, <bb_top>, <bb_width>, <bb_height>, <confidence>, <x>, <y>, <z>
@@ -106,7 +106,8 @@ def prepare_data_for_det_metrics(gt_bboxes_per_frame,
 
     target, preds = _to_tracker_format(
         gt_bboxes_per_frame, gt_track_ids_per_frame,
-        dt_bboxes_per_frame, dt_track_ids_per_frame, dt_scores_per_frame)
+        dt_bboxes_per_frame, dt_track_ids_per_frame, dt_scores_per_frame,
+        img_w=img_w, img_h=img_h)
 
 
 
@@ -282,7 +283,7 @@ def compute_metrics_by_sequence(
     pred_field: str,  # fiftyone field name
     metric_fn: callable,  # metric class
     metric_kwargs: dict,  # kwargs for metric_fn
-    sequence_list: list = [],  # list of sequence names
+    sequence_list: list = None,  # list of sequence names
     ):
 
     sequence_results = {}
@@ -309,37 +310,60 @@ def compute_metrics_by_sequence(
 def compute_all_metrics_by_sequence(
     view: fo.DatasetView,
     gt_field: str,
-    pred_field: str,
+    pred_fields: "str | list",
     metrics: list,  # list of (metric_fn, metric_kwargs) tuples
     sequence_list: list = None,
 ) -> dict:
-    """Run multiple metrics in a single pass over the FiftyOne dataset.
+    """Run multiple metrics across multiple prediction fields in a single pass.
 
     Parameters
     ----------
+    pred_fields:
+        One or more FiftyOne prediction field names. Pass a string for a single
+        model or a list to evaluate multiple models in the same pass.
     metrics:
         List of (metric_fn, metric_kwargs) tuples, e.g.:
         [(TrackingMetrics, {"max_iou": 0.5}), (HOTAMetrics, {})]
 
     Returns
     -------
-    dict mapping each metric class name to its populated metric instance,
-    e.g. {"TrackingMetrics": <TrackingMetrics>, "HOTAMetrics": <HOTAMetrics>}
-    """
-    if sequence_list is None:
-        sequence_list = get_relevant_fields(view, [gt_field, pred_field, 'sequence']).distinct("sequence")
+    Nested dict: {pred_field: {metric_class_name: metric_instance}}
 
-    instances = {fn.__name__: fn(**kwargs) for fn, kwargs in metrics}
+    Example
+    -------
+    results = compute_all_metrics_by_sequence(
+        view=view,
+        gt_field="ground_truth_det",
+        pred_fields=["model_a", "model_b"],
+        metrics=[(TrackingMetrics, {"max_iou": 0.5}), (HOTAMetrics, {})],
+    )
+    mot_df = results_to_df(results["model_a"]["TrackingMetrics"])
+    """
+    if isinstance(pred_fields, str):
+        pred_fields = [pred_fields]
+
+    if sequence_list is None:
+        sequence_list = get_relevant_fields(
+            view, [gt_field, *pred_fields, "sequence"]
+        ).distinct("sequence")
+
+    # Instantiate one set of metric objects per pred_field
+    instances = {
+        pred_field: {fn.__name__: fn(**kwargs) for fn, kwargs in metrics}
+        for pred_field in pred_fields
+    }
 
     for sequence_name in sequence_list:
         sequence_view = view.match(F("sequence") == sequence_name)
-        gt, pred = compute_metrics(view=sequence_view, gt_field=gt_field, pred_field=pred_field)
-
-        for instance in instances.values():
-            try:
-                instance.update(gt, pred, sequence_name)
-            except Exception:
-                instance.log_failed_sequence(sequence_name, gt, pred)
+        for pred_field in pred_fields:
+            gt, pred = compute_metrics(
+                view=sequence_view, gt_field=gt_field, pred_field=pred_field
+            )
+            for instance in instances[pred_field].values():
+                try:
+                    instance.update(gt, pred, sequence_name)
+                except Exception:
+                    instance.log_failed_sequence(sequence_name, gt, pred)
 
     return instances
 
@@ -546,11 +570,12 @@ def _box_xyxy_to_cxcywh(boxes):
 def results_to_df(metrics, sequence_list: list = None) -> pd.DataFrame:
     """Convert TrackingMetrics or HOTAMetrics results to a DataFrame.
 
-    Detects the metric type from the result keys and applies the appropriate
-    scaling so all values are expressed as percentages (0–100).
+    Detects the metric type from the result keys and applies metric-specific
+    scaling where implemented.
 
-    TrackingMetrics: MOTA scaled ×100, MOTP converted to (1-MOTP)×100.
-    HOTAMetrics: HOTA/DetA/AssA/LocA scaled ×100.
+    TrackingMetrics: only ``mota`` is scaled ×100 and ``motp`` is converted to
+    ``(1 - motp) × 100``; all other returned metrics are left unchanged.
+    HOTAMetrics: all returned metric values (hota, deta, assa, loca) are scaled ×100.
     """
     if sequence_list is None:
         sequence_list = list(metrics.accumulators.keys())

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -612,8 +612,8 @@ def results_to_df(metrics, sequence_list: list = None) -> pd.DataFrame:
         result = metrics.compute(sequence=sequence)
 
         if "hota" in result:
-            # HOTAMetrics: result is {metric: float}
-            row = {k: v * 100 for k, v in result.items()}
+            # HOTAMetrics: scores are in [0,1] and scaled ×100; num_unique_objects is a count
+            row = {k: (v if k == "num_unique_objects" else v * 100) for k, v in result.items()}
         else:
             # TrackingMetrics: result is {metric: {0: value}} (pandas to_dict format)
             row = {k: list(v.values())[0] for k, v in result.items()}

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -168,7 +168,7 @@ def compute_metrics(view: fo.DatasetView, # view
                     ):
     """Computes metrics for a given sequence view."""
 
-    view = get_relevant_fields(view, [gt_field, pred_field, "mux"])
+    view = get_relevant_fields(view, [gt_field, pred_field])
 
     sample = view.first()
     img_w = sample["metadata"]["frame_width"]
@@ -184,13 +184,14 @@ def compute_metrics(view: fo.DatasetView, # view
                                      f"{pred_field}.detections.confidence")
     dt_track_ids_per_frame = get_values(view,
                                      f"{pred_field}.detections.index")
-    mux = get_values(view, "mux")
 
-    gt_bboxes_per_frame = [bboxes for (mux_item,bboxes) in zip(mux, gt_bboxes_per_frame) if mux_item]
-    gt_track_ids_per_frame = [track_ids for (mux_item, track_ids)  in zip(mux, gt_track_ids_per_frame) if mux_item]
-    dt_bboxes_per_frame = [bboxes for (mux_item,bboxes) in zip(mux, dt_bboxes_per_frame) if mux_item]
-    dt_scores_per_frame = [scores for (mux_item,scores) in zip(mux, dt_scores_per_frame) if mux_item]
-    dt_track_ids_per_frame = [track_ids for (mux_item,track_ids) in zip(mux, dt_track_ids_per_frame) if mux_item]
+    if view.has_frame_field(f"{pred_field}.keyframe"):
+        keyframes = get_values(view, f"{pred_field}.keyframe")
+        gt_bboxes_per_frame = [bboxes for (kf, bboxes) in zip(keyframes, gt_bboxes_per_frame) if kf]
+        gt_track_ids_per_frame = [track_ids for (kf, track_ids) in zip(keyframes, gt_track_ids_per_frame) if kf]
+        dt_bboxes_per_frame = [bboxes for (kf, bboxes) in zip(keyframes, dt_bboxes_per_frame) if kf]
+        dt_scores_per_frame = [scores for (kf, scores) in zip(keyframes, dt_scores_per_frame) if kf]
+        dt_track_ids_per_frame = [track_ids for (kf, track_ids) in zip(keyframes, dt_track_ids_per_frame) if kf]
 
     target, preds = prepare_data_for_det_metrics(
         gt_bboxes_per_frame, gt_track_ids_per_frame,
@@ -198,7 +199,7 @@ def compute_metrics(view: fo.DatasetView, # view
         img_w=img_w, img_h=img_h)
 
     # free memory
-    del gt_bboxes_per_frame, gt_track_ids_per_frame, mux
+    del gt_bboxes_per_frame, gt_track_ids_per_frame
     del dt_bboxes_per_frame, dt_scores_per_frame, dt_track_ids_per_frame
 
     return target, preds
@@ -371,7 +372,7 @@ def compute_sizes(view: fo.DatasetView,
                     gt_field: str):  # fiftyone field name
         """Computes sizes for a given sequence view."""
 
-        view = get_relevant_fields(view, [gt_field, "mux"])
+        view = get_relevant_fields(view, [gt_field])
         sample = view.first()
         img_w = sample["metadata"]["frame_width"]
         img_h = sample["metadata"]["frame_height"]
@@ -379,11 +380,8 @@ def compute_sizes(view: fo.DatasetView,
                                          f"{gt_field}.detections.bounding_box")
         gt_track_ids_per_frame = get_values(view,
                                             f"{gt_field}.detections.index")
-        
-        #mux = get_values(view, "mux")
-        # gt_bboxes_per_frame = [bboxes for (mux_item,bboxes) in zip(mux, gt_bboxes_per_frame) if mux_item]
-        # gt_track_ids_per_frame = [track_ids for (mux_item, track_ids)  in zip(mux, gt_track_ids_per_frame) if mux_item]
-        b = [(bboxes, t_ids) for (bboxes,t_ids) in zip(gt_bboxes_per_frame, gt_track_ids_per_frame) if bboxes is not None and t_ids is not None]
+
+        b = [(bboxes, t_ids) for (bboxes, t_ids) in zip(gt_bboxes_per_frame, gt_track_ids_per_frame) if bboxes is not None and t_ids is not None]
         gt_bboxes_per_frame = [bboxes for (bboxes,_) in b]
         gt_track_ids_per_frame = [t_ids for (_,t_ids)  in b]
         objects = []

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -265,8 +265,6 @@ def compute_and_save_sequence_metrics(
                 view=sequence_view,
                 gt_field=gt_field,
                 pred_field=pred_field,
-                metric_fn=metric_fn,
-                metric_kwargs=metric_kwargs,
             )
 
         if debug:
@@ -363,8 +361,8 @@ def compute_all_metrics_by_sequence(
             for instance in instances[pred_field].values():
                 try:
                     instance.update(gt, pred, sequence_name)
-                except Exception:
-                    instance.log_failed_sequence(sequence_name, gt, pred)
+                except Exception as e:
+                    instance.log_failed_sequence(sequence_name, gt, pred, exc=e)
 
     return instances
 

--- a/tests/tracking/test_hota.py
+++ b/tests/tracking/test_hota.py
@@ -1,0 +1,185 @@
+import math
+import numpy as np
+import pytest
+from seametrics.tracking.hota import HOTAMetrics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _det(frame, obj_id, x1, y1, x2, y2, conf=1.0):
+    """Build a single row in MOT format: [frame, id, x1, y1, x2, y2, conf]."""
+    return [frame, obj_id, x1, y1, x2, y2, conf]
+
+
+def _array(*rows):
+    return np.array(rows, dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestHOTAPerfect:
+    """Perfect tracker: pred == gt in every frame."""
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 1, 1, 11, 11),
+            _det(3, 1, 2, 2, 12, 12),
+        )
+        pred = gt.copy()
+        pred[:, 6] = 0.9  # confidence column doesn't affect HOTA
+
+        self.m = HOTAMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_hota_is_one(self):
+        r = self.m.compute("seq")
+        assert r["hota"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_deta_is_one(self):
+        r = self.m.compute("seq")
+        assert r["deta"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_assa_is_one(self):
+        r = self.m.compute("seq")
+        assert r["assa"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_loca_is_one(self):
+        r = self.m.compute("seq")
+        assert r["loca"] == pytest.approx(1.0, abs=1e-6)
+
+
+class TestHOTANoGT:
+    """All predictions, no ground truth → DetA = 0 → HOTA = 0."""
+
+    def setup_method(self):
+        gt = np.empty((0, 7))
+        pred = _array(
+            _det(1, 1, 0, 0, 10, 10, 0.9),
+            _det(2, 1, 1, 1, 11, 11, 0.8),
+        )
+        self.m = HOTAMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_hota_is_zero(self):
+        r = self.m.compute("seq")
+        assert r["hota"] == pytest.approx(0.0, abs=1e-6)
+
+    def test_deta_is_zero(self):
+        r = self.m.compute("seq")
+        assert r["deta"] == pytest.approx(0.0, abs=1e-6)
+
+
+class TestHOTANoPred:
+    """All ground truth, no predictions → DetA = 0 → HOTA = 0."""
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 1, 1, 11, 11),
+        )
+        pred = np.empty((0, 7))
+        self.m = HOTAMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_hota_is_zero(self):
+        r = self.m.compute("seq")
+        assert r["hota"] == pytest.approx(0.0, abs=1e-6)
+
+    def test_deta_is_zero(self):
+        r = self.m.compute("seq")
+        assert r["deta"] == pytest.approx(0.0, abs=1e-6)
+
+
+class TestHOTAIDSwitch:
+    """
+    1 GT track, 2 predicted IDs (a clean ID switch halfway through).
+
+    Frame 1: GT id=1  matched to pred id=1  → TP
+    Frame 2: GT id=1  matched to pred id=2  → TP (ID switch)
+
+    Boxes are identical so IoU=1 and every threshold yields a TP.
+    Expected (at each α):
+        DetA = 2/2 = 1.0
+        For each TP: tpa=1, gt_count=2, pr_count=1 → A = 1/(2+1-1) = 0.5
+        AssA = 0.5
+        HOTA = sqrt(1.0 * 0.5) ≈ 0.7071
+    """
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+        )
+        pred = _array(
+            _det(1, 1, 0, 0, 10, 10),  # correct ID
+            _det(2, 2, 0, 0, 10, 10),  # switched ID
+        )
+        self.m = HOTAMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_deta_is_one(self):
+        r = self.m.compute("seq")
+        assert r["deta"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_assa_is_half(self):
+        r = self.m.compute("seq")
+        assert r["assa"] == pytest.approx(0.5, abs=1e-6)
+
+    def test_hota(self):
+        r = self.m.compute("seq")
+        assert r["hota"] == pytest.approx(math.sqrt(0.5), abs=1e-6)
+
+
+class TestHOTAPartialDetection:
+    """
+    1 GT track over 3 frames, only matched in 2 (1 FN, 0 FP).
+    Expected DetA = 2/3 at all thresholds (IoU=1).
+    """
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+            _det(3, 1, 0, 0, 10, 10),
+        )
+        pred = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+            # frame 3: no prediction
+        )
+        self.m = HOTAMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_deta(self):
+        r = self.m.compute("seq")
+        assert r["deta"] == pytest.approx(2 / 3, abs=1e-6)
+
+
+class TestHOTAGlobalAggregation:
+    """Global compute() averages per-sequence results."""
+
+    def setup_method(self):
+        # seq1: perfect → HOTA=1
+        gt1 = _array(_det(1, 1, 0, 0, 10, 10))
+        pred1 = gt1.copy()
+
+        # seq2: no predictions → HOTA=0
+        gt2 = _array(_det(1, 1, 0, 0, 10, 10))
+        pred2 = np.empty((0, 7))
+
+        self.m = HOTAMetrics()
+        self.m.update(gt1, pred1, "seq1")
+        self.m.update(gt2, pred2, "seq2")
+
+    def test_global_hota_is_mean(self):
+        r = self.m.compute()  # sequence=None
+        assert r["hota"] == pytest.approx(0.5, abs=1e-6)
+
+    def test_unknown_sequence_raises(self):
+        with pytest.raises(KeyError):
+            self.m.compute("nonexistent")

--- a/tests/tracking/test_hota.py
+++ b/tests/tracking/test_hota.py
@@ -161,14 +161,14 @@ class TestHOTAPartialDetection:
 
 
 class TestHOTAGlobalAggregation:
-    """Global compute() averages per-sequence results."""
+    """Global compute() pools TP/FP/FN counts across sequences (MOT standard)."""
 
     def setup_method(self):
-        # seq1: perfect → HOTA=1
+        # seq1: perfect → 1 TP, 0 FP, 0 FN
         gt1 = _array(_det(1, 1, 0, 0, 10, 10))
         pred1 = gt1.copy()
 
-        # seq2: no predictions → HOTA=0
+        # seq2: no predictions → 0 TP, 0 FP, 1 FN
         gt2 = _array(_det(1, 1, 0, 0, 10, 10))
         pred2 = np.empty((0, 7))
 
@@ -176,9 +176,10 @@ class TestHOTAGlobalAggregation:
         self.m.update(gt1, pred1, "seq1")
         self.m.update(gt2, pred2, "seq2")
 
-    def test_global_hota_is_mean(self):
+    def test_global_hota_pools_counts(self):
+        # Pooled: TP=1, FP=0, FN=1 → DetA=0.5, AssA=1.0 → HOTA=sqrt(0.5)
         r = self.m.compute()  # sequence=None
-        assert r["hota"] == pytest.approx(0.5, abs=1e-6)
+        assert r["hota"] == pytest.approx(0.5 ** 0.5, abs=1e-6)
 
     def test_unknown_sequence_raises(self):
         with pytest.raises(KeyError):

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -1,0 +1,207 @@
+import numpy as np
+import pytest
+
+mm = pytest.importorskip("motmetrics", reason="motmetrics not installed")
+
+from seametrics.tracking.track import TrackingMetrics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _det(frame, obj_id, x1, y1, x2, y2):
+    """Single MOT-format row: [frame, id, x1, y1, x2, y2]."""
+    return [frame, obj_id, x1, y1, x2, y2]
+
+
+def _array(*rows):
+    return np.array(rows, dtype=float)
+
+
+def _scalar(result, metric):
+    """Extract the single scalar value from a per-sequence compute() result."""
+    return list(result[metric].values())[0]
+
+
+# ---------------------------------------------------------------------------
+# Perfect tracking
+# ---------------------------------------------------------------------------
+
+class TestPerfectTracking:
+    """GT == pred in every frame."""
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 1, 1, 11, 11),
+            _det(3, 1, 2, 2, 12, 12),
+        )
+        self.m = TrackingMetrics()
+        self.m.update(gt, gt.copy(), "seq")
+
+    def test_mota_is_one(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "mota") == pytest.approx(1.0)
+
+    def test_no_misses(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_misses") == 0
+
+    def test_no_false_positives(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_false_positives") == 0
+
+    def test_no_id_switches(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_switches") == 0
+
+    def test_num_frames(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_frames") == 3
+
+
+# ---------------------------------------------------------------------------
+# No predictions
+# ---------------------------------------------------------------------------
+
+class TestNoPredicitions:
+    """GT present, pred empty → everything missed."""
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+            _det(3, 1, 0, 0, 10, 10),
+        )
+        pred = _array(_det(1, 1, 100, 100, 110, 110))   # outside IoU threshold
+        self.m = TrackingMetrics(max_iou=0.5)
+        self.m.update(gt, pred, "seq")
+
+    def test_mota(self):
+        # FN=3 (gt obj missed in all frames), FP=1, IDSW=0, GT=3
+        # MOTA = 1 - (3+1+0)/3 = -1/3
+        r = self.m.compute("seq")
+        assert _scalar(r, "mota") == pytest.approx(1 - 4 / 3)
+
+    def test_misses(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_misses") == 3
+
+    def test_false_positives(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_false_positives") == 1
+
+
+# ---------------------------------------------------------------------------
+# ID switch
+# ---------------------------------------------------------------------------
+
+class TestIDSwitch:
+    """Same GT track matched to two different predicted IDs."""
+
+    def setup_method(self):
+        # Frames 1–2: GT id=1 → pred id=1  (correct)
+        # Frame 3:    GT id=1 → pred id=2  (ID switch)
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+            _det(3, 1, 0, 0, 10, 10),
+        )
+        pred = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+            _det(3, 2, 0, 0, 10, 10),
+        )
+        self.m = TrackingMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_num_switches(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_switches") == 1
+
+    def test_mota_penalised(self):
+        # MOTA = 1 - (FN=0 + FP=0 + IDSW=1) / GT=3
+        r = self.m.compute("seq")
+        assert _scalar(r, "mota") == pytest.approx(1 - 1 / 3)
+
+    def test_idf1_below_one(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "idf1") < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Global aggregation (sequence=None)
+# ---------------------------------------------------------------------------
+
+class TestGlobalCompute:
+
+    def setup_method(self):
+        gt = _array(_det(1, 1, 0, 0, 10, 10))
+        self.m = TrackingMetrics()
+        self.m.update(gt, gt.copy(), "seq1")
+        self.m.update(gt, gt.copy(), "seq2")
+
+    def test_returns_dict(self):
+        r = self.m.compute()
+        assert isinstance(r, dict)
+
+    def test_overall_row_present(self):
+        r = self.m.compute()
+        assert "OVERALL" in r["mota"]
+
+    def test_both_sequences_present(self):
+        r = self.m.compute()
+        assert "seq1" in r["mota"]
+        assert "seq2" in r["mota"]
+
+    def test_overall_mota_is_one(self):
+        r = self.m.compute()
+        assert r["mota"]["OVERALL"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+
+    def test_unknown_sequence_raises(self):
+        m = TrackingMetrics()
+        with pytest.raises(Exception, match="Unknown sequence"):
+            m.compute("nonexistent")
+
+    def test_empty_metrics_global_returns_dict(self):
+        # compute() with no sequences loaded should still return a dict
+        m = TrackingMetrics()
+        gt = _array(_det(1, 1, 0, 0, 10, 10))
+        m.update(gt, gt.copy(), "seq")
+        r = m.compute()
+        assert "mota" in r
+
+
+# ---------------------------------------------------------------------------
+# log_failed_sequence
+# ---------------------------------------------------------------------------
+
+class TestLogFailedSequence:
+
+    def test_no_gt_and_no_pred(self):
+        m = TrackingMetrics()
+        m.log_failed_sequence("s", [], [])
+        assert m.failed_sequences["s"] == "No ground truth and no predictions"
+
+    def test_no_gt(self):
+        m = TrackingMetrics()
+        m.log_failed_sequence("s", [], [1])
+        assert m.failed_sequences["s"] == "No ground truth"
+
+    def test_no_pred(self):
+        m = TrackingMetrics()
+        m.log_failed_sequence("s", [1], [])
+        assert m.failed_sequences["s"] == "No predictions"
+
+    def test_missing_ids(self):
+        m = TrackingMetrics()
+        m.log_failed_sequence("s", [1], [1])
+        assert m.failed_sequences["s"] == "Missing IDs from GT or Pred"

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -65,7 +65,7 @@ class TestPerfectTracking:
 # No predictions
 # ---------------------------------------------------------------------------
 
-class TestNoPredicitions:
+class TestNoPredictions:
     """GT present, pred empty → everything missed."""
 
     def setup_method(self):
@@ -171,8 +171,8 @@ class TestErrorHandling:
         with pytest.raises(Exception, match="Unknown sequence"):
             m.compute("nonexistent")
 
-    def test_empty_metrics_global_returns_dict(self):
-        # compute() with no sequences loaded should still return a dict
+    def test_global_compute_returns_dict(self):
+        # compute() with at least one sequence loaded should return a dict
         m = TrackingMetrics()
         gt = _array(_det(1, 1, 0, 0, 10, 10))
         m.update(gt, gt.copy(), "seq")

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -1,5 +1,3 @@
-import pytest
-
 from seametrics.tracking import utils
 
 
@@ -67,57 +65,25 @@ class _RecordingMetric:
     def __init__(self, label=None):
         self.label = label
         self.updates = []
-        self.failed_sequences = {}
 
     def update(self, gt, pred, sequence_name):
         self.updates.append((gt, pred, sequence_name))
 
     def log_failed_sequence(self, sequence_name, gt, pred, exc=None):
-        self.failed_sequences[sequence_name] = str(exc)
+        raise AssertionError(f"unexpected failure for {sequence_name}: {exc}")
 
 
-class _RejectingMetric(_RecordingMetric):
-    def update(self, gt, pred, sequence_name):
-        raise ValueError(f"bad sequence {sequence_name}")
-
-
-class _PairMetric:
-    def __init__(self, scale):
-        self.scale = scale
-        self.updated = None
-
-    def update(self, preds, target):
-        self.updated = (preds, target)
-
-    def compute(self):
-        preds, target = self.updated
-        return {"score": len(preds) + len(target) + self.scale}
-
-
-def test_tracking_utils_build_sequences_and_format_results():
+def test_compute_all_metrics_by_sequence_uses_group_slice_and_keyframes():
     view = _FakeGroupView()
-
-    result = utils.compute_metrics(
-        view=view,
-        gt_field="gt",
-        pred_field="pred",
-        metric_fn=_PairMetric,
-        metric_kwargs={"scale": 1},
-    )
-    assert result == {"score": 5}
 
     all_metrics = utils.compute_all_metrics_by_sequence(
         view=view,
         gt_field="gt",
         pred_fields="pred",
-        metrics=[
-            (_RecordingMetric, {"label": "ok"}),
-            (_RejectingMetric, {"label": "rejecting"}),
-        ],
+        metrics=[(_RecordingMetric, {"label": "ok"})],
     )
 
     recording = all_metrics["pred"]["_RecordingMetric"]
-    rejecting = all_metrics["pred"]["_RejectingMetric"]
 
     assert view.selected_slice == "rgb"
     assert recording.label == "ok"
@@ -130,20 +96,9 @@ def test_tracking_utils_build_sequences_and_format_results():
     assert gt[:, 1].tolist() == [1, 3]
     assert pred[:, 1].tolist() == [10, 30]
     assert pred[:, 6].tolist() == [0.9, 0.7]
-    assert rejecting.failed_sequences == {"seq-1": "bad sequence seq-1"}
 
-    with pytest.raises(ValueError, match="Duplicate metric class names"):
-        utils.compute_all_metrics_by_sequence(
-            view=view,
-            gt_field="gt",
-            pred_fields="pred",
-            metrics=[
-                (_RecordingMetric, {}),
-                (_RecordingMetric, {}),
-            ],
-            sequence_list=[],
-        )
 
+def test_results_to_df_formats_hota_and_tracking_outputs():
     class _HotaResults:
         accumulators = {"seq-1": None}
 

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -1,0 +1,180 @@
+import pytest
+
+from seametrics.tracking import utils
+
+
+class _FakeVideoView:
+    media_type = "video"
+
+    def __init__(self):
+        self.selected_fields = None
+
+    def has_frame_field(self, field):
+        return field == "pred.keyframe" or field.startswith(("gt.", "pred.", "sequence"))
+
+    def select_fields(self, fields):
+        self.selected_fields = fields
+        return self
+
+    def first(self):
+        return {"metadata": {"frame_width": 100, "frame_height": 50}}
+
+    def distinct(self, field):
+        assert field == "sequence"
+        return ["seq-1"]
+
+    def match(self, _condition):
+        return self
+
+    def values(self, field):
+        values = {
+            "frames[].gt.detections.bounding_box": [
+                [[0.1, 0.2, 0.3, 0.4]],
+                [[0.2, 0.2, 0.3, 0.4]],
+                [[0.4, 0.2, 0.3, 0.4]],
+            ],
+            "frames[].gt.detections.index": [[1], [2], [3]],
+            "frames[].pred.detections.bounding_box": [
+                [[0.1, 0.2, 0.3, 0.4]],
+                [[0.2, 0.2, 0.3, 0.4]],
+                [[0.4, 0.2, 0.3, 0.4]],
+            ],
+            "frames[].pred.detections.confidence": [[0.9], [0.8], [0.7]],
+            "frames[].pred.detections.index": [[10], [20], [30]],
+            "frames[].pred.keyframe": [True, False, True],
+        }
+        return values[field]
+
+
+class _FakeGroupView:
+    media_type = "group"
+    default_group_slice = "rgb"
+    dataset_name = "dataset"
+
+    def __init__(self):
+        self.video_view = _FakeVideoView()
+        self.selected_slice = None
+
+    def select_group_slices(self, group_slice):
+        self.selected_slice = group_slice
+        return self.video_view
+
+    def match(self, _condition):
+        return self
+
+
+class _RecordingMetric:
+    def __init__(self, label=None):
+        self.label = label
+        self.updates = []
+        self.failed_sequences = {}
+
+    def update(self, gt, pred, sequence_name):
+        self.updates.append((gt, pred, sequence_name))
+
+    def log_failed_sequence(self, sequence_name, gt, pred, exc=None):
+        self.failed_sequences[sequence_name] = str(exc)
+
+
+class _RejectingMetric(_RecordingMetric):
+    def update(self, gt, pred, sequence_name):
+        raise ValueError(f"bad sequence {sequence_name}")
+
+
+class _PairMetric:
+    def __init__(self, scale):
+        self.scale = scale
+        self.updated = None
+
+    def update(self, preds, target):
+        self.updated = (preds, target)
+
+    def compute(self):
+        preds, target = self.updated
+        return {"score": len(preds) + len(target) + self.scale}
+
+
+def test_tracking_utils_build_sequences_and_format_results():
+    view = _FakeGroupView()
+
+    result = utils.compute_metrics(
+        view=view,
+        gt_field="gt",
+        pred_field="pred",
+        metric_fn=_PairMetric,
+        metric_kwargs={"scale": 1},
+    )
+    assert result == {"score": 5}
+
+    all_metrics = utils.compute_all_metrics_by_sequence(
+        view=view,
+        gt_field="gt",
+        pred_fields="pred",
+        metrics=[
+            (_RecordingMetric, {"label": "ok"}),
+            (_RejectingMetric, {"label": "rejecting"}),
+        ],
+    )
+
+    recording = all_metrics["pred"]["_RecordingMetric"]
+    rejecting = all_metrics["pred"]["_RejectingMetric"]
+
+    assert view.selected_slice == "rgb"
+    assert recording.label == "ok"
+    assert len(recording.updates) == 1
+
+    gt, pred, sequence_name = recording.updates[0]
+    assert sequence_name == "seq-1"
+    assert gt.shape == (2, 10)
+    assert pred.shape == (2, 10)
+    assert gt[:, 1].tolist() == [1, 3]
+    assert pred[:, 1].tolist() == [10, 30]
+    assert pred[:, 6].tolist() == [0.9, 0.7]
+    assert rejecting.failed_sequences == {"seq-1": "bad sequence seq-1"}
+
+    with pytest.raises(ValueError, match="Duplicate metric class names"):
+        utils.compute_all_metrics_by_sequence(
+            view=view,
+            gt_field="gt",
+            pred_fields="pred",
+            metrics=[
+                (_RecordingMetric, {}),
+                (_RecordingMetric, {}),
+            ],
+            sequence_list=[],
+        )
+
+    class _HotaResults:
+        accumulators = {"seq-1": None}
+
+        def compute(self, sequence):
+            assert sequence == "seq-1"
+            return {
+                "hota": 0.5,
+                "deta": 0.75,
+                "assa": 0.25,
+                "loca": 1.0,
+                "num_unique_objects": 2,
+            }
+
+    hota_df = utils.hota_results_to_df(_HotaResults())
+    assert hota_df.loc[0, "hota"] == 50
+    assert hota_df.loc[0, "deta"] == 75
+    assert hota_df.loc[0, "num_unique_objects"] == 2
+    assert hota_df.loc[0, "sequence"] == "seq-1"
+
+    class _TrackingResults:
+        accumulators = {"seq-1": None}
+
+        def compute(self, sequence):
+            assert sequence == "seq-1"
+            return {
+                "mota": {"seq-1": 0.25},
+                "motp": {"seq-1": 0.2},
+                "idf1": {"seq-1": 0.8},
+            }
+
+    tracking_df = utils.results_to_df(_TrackingResults())
+    assert tracking_df.loc[0, "mota"] == 25
+    assert tracking_df.loc[0, "motp"] == 80
+    assert tracking_df.loc[0, "idf1"] == 0.8


### PR DESCRIPTION
## What?

Adds HOTA (Higher Order Tracking Accuracy) metrics to the tracking module and fixes two bugs in `TrackingMetrics` that made global aggregation unreachable and image resolution hardcoded. The tracking evaluation pipeline now runs both metric families in a single pass over the FiftyOne dataset.

## Why?

HOTA is the current standard for MOT evaluation (used in MOTChallenge, BDD100K) and better balances detection and association quality than MOTA alone. The bugs and hardcoded defaults were blockers for building a reliable W&B evaluation job.

## How?

**New: `HOTAMetrics`** (`seametrics/tracking/hota.py`)
- Computes HOTA, DetA, AssA, LocA averaged over 19 IoU thresholds (0.05 → 0.95)
- Same `update` / `compute` / `log_failed_sequence` interface as `TrackingMetrics` — drop-in compatible with `compute_metrics_by_sequence`

**New: `compute_all_metrics_by_sequence`** (`seametrics/tracking/utils.py`)
- Runs multiple metric classes in a single pass over the FiftyOne dataset
- Usage:
```python
results = compute_all_metrics_by_sequence(
    view=dataset.select_group_slices(["thermal_wide"]),
    gt_field="ground_truth_det",
    pred_field="model_name",
    metrics=[
        (TrackingMetrics, {"max_iou": 0.5}),
        (HOTAMetrics, {}),
    ],
)
mot_df  = results_to_df(results["TrackingMetrics"])
hota_df = results_to_df(results["HOTAMetrics"])
```

**Bug fixes**

| Location | Bug | Fix |
|---|---|---|
| `track.py` `compute()` | `sequence=None` branch was unreachable — `None not in accumulators` raised before the None check | Moved None check first |
| `utils.py` `compute_metrics` / `compute_sizes` | `img_w=640`, `img_h=512` hardcoded | Read `frame_width` / `frame_height` from `sample["metadata"]` |

**`results_to_df` unified**
- Previously crashed with `KeyError` if passed a `HOTAMetrics` object
- Now detects metric type from result keys and applies correct scaling for both

## Backout plan

Revert the PR. No schema changes, no data migrations, no side effects on existing datasets. `TrackingMetrics` and all existing util functions are fully backward compatible.

## Testing

Tests added for both metric classes under `tests/tracking/`:

- `test_hota.py` — 6 cases: perfect tracking (HOTA=1), no GT (HOTA=0), no predictions (HOTA=0), ID switch (AssA=0.5, HOTA=√0.5), partial detection (DetA=2/3), global aggregation
- `test_tracking_metrics.py` — perfect tracking (MOTA=1), missed detections, ID switch (`num_switches=1`), global compute (`OVERALL` row present), unknown sequence raises, all `log_failed_sequence` messages

Run with:
```bash
pytest tests/tracking/ -v
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HOTA tracking metric and a bulk multi-field, multi-sequence metrics runner.

* **Improvements**
  * NumPy 2.0 compatibility fix, clearer sequence failure messages, refined aggregation behavior, and improved group-media and keyframe-aware frame filtering.

* **Tests**
  * Added comprehensive tests for HOTA and existing tracking metrics.

* **Chores**
  * Minimum Python requirement raised to 3.7; SciPy promoted to a required dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->