### PR TITLE
remove has_frame_field guard for keyframe filtering 

### DIFF
--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -378,7 +378,30 @@ def compute_all_metrics_by_sequence(
         for pred_field in pred_fields
     }
 
+    def _has_keyframes(seq_view, pred_field):
+        video_view = (
+            seq_view.select_group_slices(seq_view.default_group_slice)
+            if seq_view.media_type == "group" else seq_view
+        )
+        try:
+            kf_vals = video_view.values(f"frames[].{pred_field}.keyframe")
+            return any(kf for kf in kf_vals if kf)
+        except Exception:
+            return False
+
+    valid_sequences = []
     for sequence_name in sequence_list:
+        sequence_view = view.match(F("sequence") == sequence_name)
+        missing = [pf for pf in pred_fields if not _has_keyframes(sequence_view, pf)]
+        if missing:
+            exc = ValueError(f"No keyframe data for: {missing}")
+            for pf in pred_fields:
+                for instance in instances[pf].values():
+                    instance.log_failed_sequence(sequence_name, [], [], exc=exc)
+        else:
+            valid_sequences.append(sequence_name)
+
+    for sequence_name in valid_sequences:
         sequence_view = view.match(F("sequence") == sequence_name)
         for pred_field in pred_fields:
             gt, pred = build_detection_inputs(

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -189,13 +189,12 @@ def build_detection_inputs(
     dt_track_ids_per_frame = get_values(view,
                                      f"{pred_field}.detections.index")
 
-    if view.has_frame_field(f"{pred_field}.keyframe"):
-        keyframes = get_values(view, f"{pred_field}.keyframe")
-        gt_bboxes_per_frame = [bboxes for (kf, bboxes) in zip(keyframes, gt_bboxes_per_frame) if kf]
-        gt_track_ids_per_frame = [track_ids for (kf, track_ids) in zip(keyframes, gt_track_ids_per_frame) if kf]
-        dt_bboxes_per_frame = [bboxes for (kf, bboxes) in zip(keyframes, dt_bboxes_per_frame) if kf]
-        dt_scores_per_frame = [scores for (kf, scores) in zip(keyframes, dt_scores_per_frame) if kf]
-        dt_track_ids_per_frame = [track_ids for (kf, track_ids) in zip(keyframes, dt_track_ids_per_frame) if kf]
+    keyframes = get_values(view, f"{pred_field}.keyframe")
+    gt_bboxes_per_frame = [bboxes for (kf, bboxes) in zip(keyframes, gt_bboxes_per_frame) if kf]
+    gt_track_ids_per_frame = [track_ids for (kf, track_ids) in zip(keyframes, gt_track_ids_per_frame) if kf]
+    dt_bboxes_per_frame = [bboxes for (kf, bboxes) in zip(keyframes, dt_bboxes_per_frame) if kf]
+    dt_scores_per_frame = [scores for (kf, scores) in zip(keyframes, dt_scores_per_frame) if kf]
+    dt_track_ids_per_frame = [track_ids for (kf, track_ids) in zip(keyframes, dt_track_ids_per_frame) if kf]
 
     target, preds = prepare_data_for_det_metrics(
         gt_bboxes_per_frame, gt_track_ids_per_frame,

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -98,6 +98,92 @@ def test_compute_all_metrics_by_sequence_uses_group_slice_and_keyframes():
     assert pred[:, 6].tolist() == [0.9, 0.7]
 
 
+def test_sequence_skipped_when_keyframe_lookup_raises():
+    """_has_keyframes except branch: returns False when values() raises."""
+    failures = []
+
+    class _CapturingMetric:
+        def __init__(self): pass
+        def update(self, gt, pred, seq): raise AssertionError("should not be called")
+        def log_failed_sequence(self, seq, gt, pred, exc=None):
+            failures.append((seq, exc))
+
+    class _ErrorView(_FakeVideoView):
+        def values(self, field):
+            if "keyframe" in field:
+                raise RuntimeError("field not found")
+            return super().values(field)
+
+    utils.compute_all_metrics_by_sequence(
+        view=_ErrorView(),
+        gt_field="gt",
+        pred_fields=["pred"],
+        metrics=[(_CapturingMetric, {})],
+    )
+
+    assert len(failures) == 1
+    seq, exc = failures[0]
+    assert seq == "seq-1"
+    assert "pred" in str(exc)
+
+
+def test_sequence_skipped_when_no_true_keyframes():
+    """_has_keyframes returns False when all keyframe values are False."""
+    failures = []
+
+    class _CapturingMetric:
+        def __init__(self): pass
+        def update(self, gt, pred, seq): raise AssertionError("should not be called")
+        def log_failed_sequence(self, seq, gt, pred, exc=None):
+            failures.append((seq, exc))
+
+    class _NoKeyframeView(_FakeVideoView):
+        def values(self, field):
+            if "keyframe" in field:
+                return [False, False, False]
+            return super().values(field)
+
+    utils.compute_all_metrics_by_sequence(
+        view=_NoKeyframeView(),
+        gt_field="gt",
+        pred_fields=["pred"],
+        metrics=[(_CapturingMetric, {})],
+    )
+
+    assert len(failures) == 1
+    assert failures[0][0] == "seq-1"
+    assert "pred" in str(failures[0][1])
+
+
+def test_sequence_skipped_logs_all_pred_fields_when_one_missing():
+    """When one pred_field lacks keyframes, all pred_fields are logged as failed."""
+    failures = []
+
+    class _CapturingMetric:
+        def __init__(self): pass
+        def update(self, gt, pred, seq): raise AssertionError("should not be called")
+        def log_failed_sequence(self, seq, gt, pred, exc=None):
+            failures.append(seq)
+
+    class _PartialKeyframeView(_FakeVideoView):
+        def values(self, field):
+            if "pred_a.keyframe" in field:
+                return [True, False, True]
+            if "pred_b.keyframe" in field:
+                return [False, False, False]
+            return super().values(field)
+
+    utils.compute_all_metrics_by_sequence(
+        view=_PartialKeyframeView(),
+        gt_field="gt",
+        pred_fields=["pred_a", "pred_b"],
+        metrics=[(_CapturingMetric, {})],
+    )
+
+    assert len(failures) == 2
+    assert all(seq == "seq-1" for seq in failures)
+
+
 def test_results_to_df_formats_hota_and_tracking_outputs():
     class _HotaResults:
         accumulators = {"seq-1": None}


### PR DESCRIPTION
## What?

`build_detection_inputs` was guarding the keyframe filter with `view.has_frame_field()`, which silently skips filtering for fields where `keyframe` is stored as a dynamic attribute (not in the declared FiftyOne schema). After this change, keyframe values are always read directly — filtering is always applied.

## Why?

Tracking metrics were being computed over all frames instead of keyframes only, producing incorrect results. Identified during end-to-end testing on `QA_SENTRY_2026_03_VIDEO_BB`.

## How?

Removed the `has_frame_field` guard in `build_detection_inputs`:

```python
# Before
if view.has_frame_field(f"{pred_field}.keyframe"):
    keyframes = get_values(view, f"{pred_field}.keyframe")
    ...

# After
keyframes = get_values(view, f"{pred_field}.keyframe")
...
```

`get_values` calls `view.values()` which can read dynamic attributes even when they are absent from the schema.

## Backout plan

Revert the single line change — add back the `if view.has_frame_field(...)` guard. The previous behaviour computes metrics over all frames rather than keyframes only.

## Testing

Tested on sequence `PROACT_CELADON_S@6m_FB_SUNRISE_20230720_2023_02_07_16_30_01`, pred field `danv2_sentry_v0_engine_c457a6e_test_frame_diff_workaround_final_oversea_det`:

| | GT rows | Pred rows |
|---|---|---|
| Before (all frames) | 3327 | 2845 |
| After (keyframes only) | 883 | 750 |

Matches expected keyframe count of 725 out of 2744 total frames. All 37 unit tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent keyframe-based filtering applied when processing detection data; sequences lacking keyframe info are skipped and recorded as failed to improve metric reliability and diagnostics.

* **Tests**
  * Added unit tests covering sequence skipping and failure logging when keyframe discovery fails or yields no valid keyframes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SEA-AI/seametrics/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->