### PR TITLE
only common sequences get in the table

### DIFF
--- a/seametrics/tracking/report.py
+++ b/seametrics/tracking/report.py
@@ -467,12 +467,13 @@ def build_comparison_html(dfs: dict) -> str:
     pred_fields = list(dfs.keys())
     metric_names = list(next(iter(dfs.values())).keys())
     sequences = sorted(
-        {
-            seq
-            for pf_val in dfs.values()
-            for mn_key in metric_names
-            for seq in pf_val[mn_key]["sequence"]
-        }
+        set.intersection(
+            *[
+                set(pf_val[mn_key]["sequence"])
+                for pf_val in dfs.values()
+                for mn_key in metric_names
+            ]
+        )
     )
     metric_cols = {
         m: [c for c in next(iter(dfs.values()))[m].columns if c != "sequence"]

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -707,6 +707,21 @@ def compute_all_metrics_by_sequence(
     }
     valid_sequences = _filter_valid_sequences(resolved, view, pred_fields, instances)
     _run_metric_updates(valid_sequences, view, pred_fields, gt_field, instances)
+
+    # Ensure consistent results: any sequence that failed for one pred_field is
+    # marked as failed for all, so results_to_df returns the same sequence set
+    # across every pred_field.
+    all_failed: set[str] = {
+        seq
+        for pf_instances in instances.values()
+        for instance in pf_instances.values()
+        for seq in instance.failed_sequences
+    }
+    for pf_instances in instances.values():
+        for instance in pf_instances.values():
+            for seq in all_failed - set(instance.failed_sequences):
+                instance.log_failed_sequence(seq, [], [], exc=None)
+
     return instances
 
 

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -75,6 +75,7 @@ class _RecordingMetric:
     def __init__(self, label=None) -> None:
         self.label = label
         self.updates = []
+        self.failed_sequences: dict = {}
 
     def update(self, gt, pred, sequence_name):
         self.updates.append((gt, pred, sequence_name))
@@ -125,13 +126,14 @@ def test_sequence_skipped_when_keyframe_lookup_raises():
 
     class _CapturingMetric:
         def __init__(self) -> None:
-            pass
+            self.failed_sequences: dict = {}
 
         def update(self, _gt, _pred, _seq):
             raise AssertionError("should not be called")
 
         def log_failed_sequence(self, seq, _gt, _pred, **_kwargs: object):
             failures.append((seq, _kwargs.get("exc")))
+            self.failed_sequences[seq] = str(_kwargs.get("exc"))
 
     class _ErrorView(_FakeVideoView):
         def values(self, field):
@@ -159,13 +161,14 @@ def test_sequence_skipped_when_no_true_keyframes():
 
     class _CapturingMetric:
         def __init__(self) -> None:
-            pass
+            self.failed_sequences: dict = {}
 
         def update(self, _gt, _pred, _seq):
             raise AssertionError("should not be called")
 
         def log_failed_sequence(self, seq, _gt, _pred, **_kwargs: object):
             failures.append((seq, _kwargs.get("exc")))
+            self.failed_sequences[seq] = str(_kwargs.get("exc"))
 
     class _NoKeyframeView(_FakeVideoView):
         def values(self, field):
@@ -192,13 +195,14 @@ def test_sequence_skipped_logs_all_pred_fields_when_one_missing():
 
     class _CapturingMetric:
         def __init__(self) -> None:
-            pass
+            self.failed_sequences: dict = {}
 
         def update(self, _gt, _pred, _seq):
             raise AssertionError("should not be called")
 
         def log_failed_sequence(self, seq, _gt, _pred, **_kwargs: object):
             failures.append(seq)
+            self.failed_sequences[seq] = str(_kwargs.get("exc"))
 
     class _PartialKeyframeView(_FakeVideoView):
         def values(self, field):


### PR DESCRIPTION
## What?

Previously, the comparison HTML report could include sequences that were only present in some prediction fields, leading to misaligned rows in the table. After this change, the table only shows sequences that appear across **all** prediction fields, and any sequence that fails for one pred_field is propagated as failed for all, guaranteeing a consistent sequence set.

## Why?

Inconsistent sequence sets between prediction fields caused confusing/broken comparison tables in tracking reports. This was surfaced during report generation when comparing models evaluated on partially overlapping sequence list.

## How?

Two changes:

1. **`report.py` — `build_comparison_html`**: sequence list is now computed via `set.intersection` across all pred_field/metric combinations instead of a union, so only sequences common to every field appear in the table.

2. **`utils.py` — `compute_all_metrics_by_sequence`**: after metric updates run, any sequence that failed for *any* pred_field instance is propagated to *all* instances via `log_failed_sequence`. This ensures `results_to_df` returns the same sequence set regardless of which pred_field is queried.

## Backout plan

Revert commit `e0080a8`. The change is isolated to report generation and metric aggregation.

## Testing

Run the tracking metric suite:

```bash
uv run pytest tests/tracking/ -v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent failed-sequence reporting so all prediction models cover the same set of sequences in generated results.
  * Improved comparison report accuracy by limiting displayed sequences to those available across all relevant metric groups, affecting rendered tables and charts.

* **Tests**
  * Updated tracking test utilities to capture and validate failed-sequence details consistently in failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->