### PR TITLE
refactor(tracking): unify metric batching and simplify report assembly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ jobs = 0
 ignore-paths = ["^tests/.*$", "^docs/.*$", "^build/.*$", "^\\.venv/.*$"]
 max-args = 10
 max-attributes = 10
-max-locals = 20
 max-line-length = 120
 min-similarity-lines = 6
 disable = [

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -5,7 +5,7 @@ from collections import Counter, defaultdict
 import numpy as np
 from scipy.optimize import linear_sum_assignment
 
-from .utils import failed_sequence_reason
+from .utils import OVERALL_LABEL, failed_sequence_reason
 
 _HOTA_THRESHOLDS = np.arange(0.05, 0.95 + 1e-9, 0.05)  # 19 values: 0.05 … 0.95
 
@@ -76,6 +76,9 @@ class HOTAMetrics:
         [frame_id, obj_id, x1, y1, x2, y2, confidence, ...]
     """
 
+    #: ``compute(str)`` returns flat scalars; use :meth:`compute_many` for tables.
+    RESULT_LAYOUT = "flat"
+
     def __init__(self, **kwargs: object) -> None:
         """Initialise empty accumulators; extra kwargs are set as attributes."""
         self.accumulators: dict = {}  # sequence_name -> (gt_array, pred_array)
@@ -132,6 +135,34 @@ class HOTAMetrics:
             raise KeyError(f"Unknown sequence: {sequence}")
         gt, pred = self.accumulators[sequence]
         return self._compute_hota(gt, pred)
+
+    def compute_many(self, names: list) -> dict:
+        """Return motmetrics-style ``{metric: {seq: val, OVERALL: val}}``.
+
+        Per-sequence and pooled results are produced in one call so table
+        exporters avoid N+1 ``compute()`` invocations.
+        """
+        duplicates = sorted(n for n, c in Counter(names).items() if c > 1)
+        if duplicates:
+            raise KeyError(f"Duplicate sequence: {duplicates}")
+        unknown = [n for n in names if n not in self.accumulators]
+        if unknown:
+            raise KeyError(f"Unknown sequence: {unknown}")
+        if not names:
+            return {}
+
+        per_seq = {
+            name: self._compute_hota(*self.accumulators[name]) for name in names
+        }
+        pooled_gt, pooled_pred = self._pool([self.accumulators[n] for n in names])
+        overall = self._compute_hota(pooled_gt, pooled_pred)
+        return {
+            metric: {
+                **{name: per_seq[name][metric] for name in names},
+                OVERALL_LABEL: overall[metric],
+            }
+            for metric in overall
+        }
 
     @staticmethod
     def _pool(entries: list) -> tuple:
@@ -233,16 +264,16 @@ class HOTAMetrics:
         self, frame_cache: list, gt_track_frames: dict, pred_track_frames: dict
     ) -> dict:
         """Average DetA/AssA/LoCA/HOTA over every IoU threshold."""
-        deta_vals, assa_vals, loca_vals, hota_vals = [], [], [], []
-        for alpha in self.iou_thresholds:
-            tp_list, n_fp, n_fn = self._match_frames(frame_cache, alpha)
-            deta, assa, loca = self._scores_at_alpha(
-                tp_list, n_fp, n_fn, gt_track_frames, pred_track_frames
+        threshold_scores = [
+            self._scores_at_alpha(
+                *self._match_frames(frame_cache, alpha),
+                gt_track_frames,
+                pred_track_frames,
             )
-            deta_vals.append(deta)
-            assa_vals.append(assa)
-            loca_vals.append(loca)
-            hota_vals.append((deta * assa) ** 0.5)
+            for alpha in self.iou_thresholds
+        ]
+        deta_vals, assa_vals, loca_vals = map(list, zip(*threshold_scores, strict=False))
+        hota_vals = [(d * a) ** 0.5 for d, a, _ in threshold_scores]
         return {
             "hota": float(np.mean(hota_vals)),
             "deta": float(np.mean(deta_vals)),

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -151,9 +151,7 @@ class HOTAMetrics:
         if not names:
             return {}
 
-        per_seq = {
-            name: self._compute_hota(*self.accumulators[name]) for name in names
-        }
+        per_seq = {name: self._compute_hota(*self.accumulators[name]) for name in names}
         pooled_gt, pooled_pred = self._pool([self.accumulators[n] for n in names])
         overall = self._compute_hota(pooled_gt, pooled_pred)
         return {
@@ -272,7 +270,9 @@ class HOTAMetrics:
             )
             for alpha in self.iou_thresholds
         ]
-        deta_vals, assa_vals, loca_vals = map(list, zip(*threshold_scores, strict=False))
+        deta_vals, assa_vals, loca_vals = map(
+            list, zip(*threshold_scores, strict=False)
+        )
         hota_vals = [(d * a) ** 0.5 for d, a, _ in threshold_scores]
         return {
             "hota": float(np.mean(hota_vals)),

--- a/seametrics/tracking/report.py
+++ b/seametrics/tracking/report.py
@@ -111,9 +111,7 @@ def _round_or_none(val: float) -> float | None:
     return round(float(val), 2) if pd.notna(val) else None
 
 
-def _iter_pf_mn_col(
-    pred_fields: list, metric_names: list, metric_cols: dict
-) -> chain:
+def _iter_pf_mn_col(pred_fields: list, metric_names: list, metric_cols: dict) -> chain:
     """Yield ``(pred_field, metric_name, column)`` triples in display order."""
     return chain.from_iterable(
         product([pf], [mn], metric_cols[mn])
@@ -124,9 +122,7 @@ def _iter_pf_mn_col(
 
 def _iter_mn_col(metric_names: list, metric_cols: dict) -> chain:
     """Yield ``(metric_name, column)`` pairs in display order."""
-    return chain.from_iterable(
-        product([mn], metric_cols[mn]) for mn in metric_names
-    )
+    return chain.from_iterable(product([mn], metric_cols[mn]) for mn in metric_names)
 
 
 def _summary_values(
@@ -211,7 +207,7 @@ def _summary_cells(
     """Build summary-row metric cells."""
     cells = "".join(
         f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
-        f"{_fmt_cell(val) if (val := summary[(pf, mn, col)]) is not None else ''}</td>"
+        f"{_fmt_cell(val) if (val := summary[pf, mn, col]) is not None else ''}</td>"
         for pf, mn, col in pf_mn_col
     )
     if show_diff:
@@ -341,9 +337,7 @@ def _build_diff_controls(pred_fields: list, show_diff: bool) -> str:
     )
 
 
-def _table_layout(
-    pred_fields: list, metric_names: list, metric_cols: dict
-) -> dict:
+def _table_layout(pred_fields: list, metric_names: list, metric_cols: dict) -> dict:
     """Pre-compute table iteration order and diff-column flags."""
     return {
         "show_diff": len(pred_fields) >= 2,  # noqa: PLR2004
@@ -369,6 +363,12 @@ def _assemble_html_table(
     mn_col = layout["mn_col"]
     pf_idx = layout["pf_idx"]
     show_diff = layout["show_diff"]
+    body_rows = _sequence_rows(
+        sequences, pf_mn_col, mn_col, dfs, show_diff=show_diff, pf_idx=pf_idx
+    )
+    summary_row = _summary_cells(
+        pf_mn_col, mn_col, summary, show_diff=show_diff, pf_idx=pf_idx
+    )
     return (
         _build_diff_controls(pred_fields, show_diff)
         + f"""<table id="seq-table">
@@ -394,11 +394,9 @@ def _assemble_html_table(
         }</tr>
     </thead>
     <tbody>
-      {_sequence_rows(sequences, pf_mn_col, mn_col, dfs, show_diff=show_diff, pf_idx=pf_idx)}
+      {body_rows}
       <tr id="mean-row" style="font-weight:bold;border-top:2px solid #e94560;">
-        <td>OVERALL / SUM</td>{
-            _summary_cells(pf_mn_col, mn_col, summary, show_diff=show_diff, pf_idx=pf_idx)
-        }
+        <td>OVERALL / SUM</td>{summary_row}
       </tr>
     </tbody>
   </table>"""
@@ -415,7 +413,7 @@ def _build_chart_section(
     """Build the chart-data dict, model checkboxes, tab buttons, and chart grids."""
     chart_data = {
         mn: {
-            col: {pf: summary[(pf, mn, col)] for pf in pred_fields}
+            col: {pf: summary[pf, mn, col] for pf in pred_fields}
             for col in metric_cols[mn]
         }
         for mn in metric_names
@@ -463,7 +461,7 @@ def _overall_data_from_summary(
     """Re-nest flat summary values for client-side diff computation."""
     return {
         pf: {
-            mn: {col: summary[(pf, mn, col)] for col in metric_cols[mn]}
+            mn: {col: summary[pf, mn, col] for col in metric_cols[mn]}
             for mn in metric_names
         }
         for pf in pred_fields

--- a/seametrics/tracking/report.py
+++ b/seametrics/tracking/report.py
@@ -3,6 +3,7 @@
 import html
 import json
 import pathlib
+from itertools import chain, product
 
 import pandas as pd
 
@@ -106,19 +107,164 @@ def _agg(df: pd.DataFrame, col: str) -> float:
 
 
 def _round_or_none(val: float) -> float | None:
-    """Round *val* to two decimal places, or return ``None`` if it is NaN.
-
-    Parameters
-    ----------
-    val : float
-        Numeric value to round.
-
-    Returns:
-    -------
-    float or None
-        Rounded value, or ``None`` when *val* is NaN / NA.
-    """
+    """Round *val* to two decimal places, or return ``None`` if it is NaN."""
     return round(float(val), 2) if pd.notna(val) else None
+
+
+def _iter_pf_mn_col(
+    pred_fields: list, metric_names: list, metric_cols: dict
+) -> chain:
+    """Yield ``(pred_field, metric_name, column)`` triples in display order."""
+    return chain.from_iterable(
+        product([pf], [mn], metric_cols[mn])
+        for pf in pred_fields
+        for mn in metric_names
+    )
+
+
+def _iter_mn_col(metric_names: list, metric_cols: dict) -> chain:
+    """Yield ``(metric_name, column)`` pairs in display order."""
+    return chain.from_iterable(
+        product([mn], metric_cols[mn]) for mn in metric_names
+    )
+
+
+def _summary_values(
+    pred_fields: list,
+    metric_names: list,
+    metric_cols: dict,
+    dfs: dict,
+) -> dict[tuple[str, str, str], float | None]:
+    """Compute pooled summary values once for table and chart consumers."""
+    return {
+        (pf, mn, col): _round_or_none(_agg(dfs[pf][mn], col))
+        for pf, mn, col in _iter_pf_mn_col(pred_fields, metric_names, metric_cols)
+    }
+
+
+def _sortable_headers(
+    pf_mn_col: list,
+    mn_col: list,
+    *,
+    show_diff: bool,
+    pf_idx: dict,
+    n_regular_cols: int,
+) -> str:
+    """Build sortable column header cells."""
+    headers = "".join(
+        f'<th class="sortable" data-label="{_h(col)}" data-pf="{pf_idx[pf]}"'
+        f' onclick="sortTable({i + 1})" title="Sort by {_h(col)}">{_h(col)}</th>'
+        for i, (pf, _mn, col) in enumerate(pf_mn_col)
+    )
+    if show_diff:
+        headers += "".join(
+            f'<th class="sortable" data-label="Δ {_h(col)}"'
+            f' onclick="sortTable({n_regular_cols + i + 1})"'
+            f' title="Sort by Δ {_h(col)}">Δ {_h(col)}</th>'
+            for i, (_mn, col) in enumerate(mn_col)
+        )
+    return headers
+
+
+def _sequence_rows(
+    sequences: list,
+    pf_mn_col: list,
+    mn_col: list,
+    dfs: dict,
+    *,
+    show_diff: bool,
+    pf_idx: dict,
+) -> str:
+    """Build per-sequence table body rows."""
+    return "".join(
+        "<tr><td>"
+        + _h(seq)
+        + "</td>"
+        + "".join(
+            f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
+            f"{_fmt_cell(_cell_value(dfs, pf, mn, col, seq))}</td>"
+            for pf, mn, col in pf_mn_col
+        )
+        + (
+            "".join(
+                f'<td style="text-align:right;" data-diff'
+                f' data-mn="{_h(mn)}" data-col="{_h(col)}"'
+                f' data-seq="{_h(seq)}"></td>'
+                for mn, col in mn_col
+            )
+            if show_diff
+            else ""
+        )
+        + "</tr>"
+        for seq in sequences
+    )
+
+
+def _summary_cells(
+    pf_mn_col: list,
+    mn_col: list,
+    summary: dict[tuple[str, str, str], float | None],
+    *,
+    show_diff: bool,
+    pf_idx: dict,
+) -> str:
+    """Build summary-row metric cells."""
+    cells = "".join(
+        f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
+        f"{_fmt_cell(val) if (val := summary[(pf, mn, col)]) is not None else ''}</td>"
+        for pf, mn, col in pf_mn_col
+    )
+    if show_diff:
+        cells += "".join(
+            f'<td style="text-align:right;" data-diff-mean'
+            f' data-mn="{_h(mn)}" data-col="{_h(col)}"></td>'
+            for mn, col in mn_col
+        )
+    return cells
+
+
+def _pred_field_headers(
+    pred_fields: list, n_cols_per_model: int, pf_idx: dict, *, show_diff: bool
+) -> str:
+    """Build top-row model name headers."""
+    headers = "".join(
+        f'<th colspan="{n_cols_per_model}" data-pf="{pf_idx[pf]}"'
+        f' style="border-left:2px solid #e94560;">{_h(pf)}</th>'
+        for pf in pred_fields
+    )
+    if show_diff:
+        headers += (
+            f'<th colspan="{n_cols_per_model}"'
+            f' style="border-left:2px solid #e94560;">'
+            f'<span id="diff-label">Δ</span></th>'
+        )
+    return headers
+
+
+def _metric_name_headers(
+    pred_fields: list,
+    metric_names: list,
+    metric_cols: dict,
+    pf_idx: dict,
+    *,
+    show_diff: bool,
+) -> str:
+    """Build second-row metric group headers."""
+    headers = "".join(
+        f'<th colspan="{len(metric_cols[mn])}" data-pf="{pf_idx[pf]}"'
+        f' style="border-left:2px solid #0f3460;">'
+        f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
+        for pf in pred_fields
+        for mn in metric_names
+    )
+    if show_diff:
+        headers += "".join(
+            f'<th colspan="{len(metric_cols[mn])}"'
+            f' style="border-left:2px solid #0f3460;">'
+            f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
+            for mn in metric_names
+        )
+    return headers
 
 
 def _cell_value(dfs: dict, pf: str, mn: str, col: str, seq: str) -> float:
@@ -195,136 +341,64 @@ def _build_diff_controls(pred_fields: list, show_diff: bool) -> str:
     )
 
 
+def _table_layout(
+    pred_fields: list, metric_names: list, metric_cols: dict
+) -> dict:
+    """Pre-compute table iteration order and diff-column flags."""
+    return {
+        "show_diff": len(pred_fields) >= 2,  # noqa: PLR2004
+        "pf_idx": {pf: i for i, pf in enumerate(pred_fields)},
+        "n_cols_per_model": sum(len(metric_cols[mn]) for mn in metric_names),
+        "pf_mn_col": list(_iter_pf_mn_col(pred_fields, metric_names, metric_cols)),
+        "mn_col": list(_iter_mn_col(metric_names, metric_cols)),
+    }
+
+
 def _assemble_html_table(
+    sequences: list,
+    dfs: dict,
+    summary: dict[tuple[str, str, str], float | None],
+    layout: dict,
+    *,
     pred_fields: list,
     metric_names: list,
     metric_cols: dict,
-    sequences: list,
-    dfs: dict,
-    *,
-    show_diff: bool,
-    pf_idx: dict,
-    n_cols_per_model: int,
-    pf_mn_col: list,
-    mn_col: list,
 ) -> str:
-    """Assemble the full ``<table>`` HTML string from pre-computed layout values.
-
-    Parameters
-    ----------
-    pred_fields : list
-        Ordered list of prediction field names.
-    metric_names : list
-        Ordered list of metric group names.
-    metric_cols : dict
-        Mapping from metric name to its column names.
-    sequences : list
-        Sorted list of all sequence names.
-    dfs : dict
-        Nested data dict: ``{pred_field: {metric_name: df}}``.
-    show_diff : bool
-        Whether to render diff columns and controls.
-    pf_idx : dict
-        Mapping from prediction field name to its 0-based index.
-    n_cols_per_model : int
-        Number of metric columns per model (used for header colspan).
-
-    Returns:
-    -------
-    str
-        Complete diff-controls + ``<table>`` HTML.
-    """
-    n_regular_cols = len(pf_mn_col)
-
-    sortable_headers = "".join(
-        f'<th class="sortable" data-label="{_h(col)}" data-pf="{pf_idx[pf]}"'
-        f' onclick="sortTable({i + 1})" title="Sort by {_h(col)}">{_h(col)}</th>'
-        for i, (pf, mn, col) in enumerate(pf_mn_col)
-    )
-    if show_diff:
-        sortable_headers += "".join(
-            f'<th class="sortable" data-label="Δ {_h(col)}"'
-            f' onclick="sortTable({n_regular_cols + i + 1})"'
-            f' title="Sort by Δ {_h(col)}">Δ {_h(col)}</th>'
-            for i, (mn, col) in enumerate(mn_col)
-        )
-
-    table_rows = "".join(
-        "<tr><td>"
-        + _h(seq)
-        + "</td>"
-        + "".join(
-            f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
-            f"{_fmt_cell(_cell_value(dfs, pf, mn, col, seq))}</td>"
-            for pf, mn, col in pf_mn_col
-        )
-        + (
-            "".join(
-                f'<td style="text-align:right;" data-diff'
-                f' data-mn="{_h(mn)}" data-col="{_h(col)}"'
-                f' data-seq="{_h(seq)}"></td>'
-                for mn, col in mn_col
-            )
-            if show_diff
-            else ""
-        )
-        + "</tr>"
-        for seq in sequences
-    )
-
-    agg_cells = "".join(
-        f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
-        f"{_agg(dfs[pf][mn], col):.2f}</td>"
-        for pf, mn, col in pf_mn_col
-    )
-    if show_diff:
-        agg_cells += "".join(
-            f'<td style="text-align:right;" data-diff-mean'
-            f' data-mn="{_h(mn)}" data-col="{_h(col)}"></td>'
-            for mn, col in mn_col
-        )
-
-    pred_field_headers = "".join(
-        f'<th colspan="{n_cols_per_model}" data-pf="{pf_idx[pf]}"'
-        f' style="border-left:2px solid #e94560;">{_h(pf)}</th>'
-        for pf in pred_fields
-    )
-    if show_diff:
-        pred_field_headers += (
-            f'<th colspan="{n_cols_per_model}"'
-            f' style="border-left:2px solid #e94560;">'
-            f'<span id="diff-label">Δ</span></th>'
-        )
-
-    metric_name_headers = "".join(
-        f'<th colspan="{len(metric_cols[mn])}" data-pf="{pf_idx[pf]}"'
-        f' style="border-left:2px solid #0f3460;">'
-        f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
-        for pf in pred_fields
-        for mn in metric_names
-    )
-    if show_diff:
-        metric_name_headers += "".join(
-            f'<th colspan="{len(metric_cols[mn])}"'
-            f' style="border-left:2px solid #0f3460;">'
-            f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
-            for mn in metric_names
-        )
-
-    diff_controls = _build_diff_controls(pred_fields, show_diff)
-
+    """Assemble the full ``<table>`` HTML string from pre-computed layout values."""
+    pf_mn_col = layout["pf_mn_col"]
+    mn_col = layout["mn_col"]
+    pf_idx = layout["pf_idx"]
+    show_diff = layout["show_diff"]
     return (
-        diff_controls
+        _build_diff_controls(pred_fields, show_diff)
         + f"""<table id="seq-table">
     <thead>
-      <tr><th rowspan="3">Sequence</th>{pred_field_headers}</tr>
-      <tr>{metric_name_headers}</tr>
-      <tr>{sortable_headers}</tr>
+      <tr><th rowspan="3">Sequence</th>{
+            _pred_field_headers(
+                pred_fields, layout["n_cols_per_model"], pf_idx, show_diff=show_diff
+            )
+        }</tr>
+      <tr>{
+            _metric_name_headers(
+                pred_fields, metric_names, metric_cols, pf_idx, show_diff=show_diff
+            )
+        }</tr>
+      <tr>{
+            _sortable_headers(
+                pf_mn_col,
+                mn_col,
+                show_diff=show_diff,
+                pf_idx=pf_idx,
+                n_regular_cols=len(pf_mn_col),
+            )
+        }</tr>
     </thead>
     <tbody>
-      {table_rows}
+      {_sequence_rows(sequences, pf_mn_col, mn_col, dfs, show_diff=show_diff, pf_idx=pf_idx)}
       <tr id="mean-row" style="font-weight:bold;border-top:2px solid #e94560;">
-        <td>OVERALL / SUM</td>{agg_cells}
+        <td>OVERALL / SUM</td>{
+            _summary_cells(pf_mn_col, mn_col, summary, show_diff=show_diff, pf_idx=pf_idx)
+        }
       </tr>
     </tbody>
   </table>"""
@@ -335,36 +409,17 @@ def _build_chart_section(
     pred_fields: list,
     metric_names: list,
     metric_cols: dict,
-    dfs: dict,
+    summary: dict[tuple[str, str, str], float | None],
     color_map: dict,
 ) -> tuple[dict, str, str, str]:
-    """Build the chart-data dict, model checkboxes, tab buttons, and chart grids.
-
-    Parameters
-    ----------
-    pred_fields : list
-        Ordered list of prediction field names (one per model).
-    metric_names : list
-        Ordered list of metric group names.
-    metric_cols : dict
-        Mapping from metric name to its column names.
-    dfs : dict
-        Nested data dict: ``{pred_field: {metric_name: df}}``.
-    color_map : dict
-        Mapping from prediction field name to CSS colour string.
-
-    Returns:
-    -------
-    tuple[dict, str, str, str]
-        ``(chart_data, checkboxes_html, tab_buttons_html, chart_grids_html)``
-    """
-    chart_data: dict = {}
-    for mn in metric_names:
-        chart_data[mn] = {}
-        for col in metric_cols[mn]:
-            chart_data[mn][col] = {
-                pf: _round_or_none(_agg(dfs[pf][mn], col)) for pf in pred_fields
-            }
+    """Build the chart-data dict, model checkboxes, tab buttons, and chart grids."""
+    chart_data = {
+        mn: {
+            col: {pf: summary[(pf, mn, col)] for pf in pred_fields}
+            for col in metric_cols[mn]
+        }
+        for mn in metric_names
+    }
 
     checkboxes_html = "".join(
         f'<label style="margin-right:16px;cursor:pointer;color:{color_map[pf]};">'
@@ -399,34 +454,33 @@ def _build_chart_section(
     return chart_data, checkboxes_html, tab_buttons, chart_grids
 
 
+def _overall_data_from_summary(
+    summary: dict[tuple[str, str, str], float | None],
+    pred_fields: list,
+    metric_names: list,
+    metric_cols: dict,
+) -> dict:
+    """Re-nest flat summary values for client-side diff computation."""
+    return {
+        pf: {
+            mn: {col: summary[(pf, mn, col)] for col in metric_cols[mn]}
+            for mn in metric_names
+        }
+        for pf in pred_fields
+    }
+
+
 def _build_table_html(
     pred_fields: list,
     metric_names: list,
     metric_cols: dict,
     sequences: list,
     dfs: dict,
+    *,
+    summary: dict[tuple[str, str, str], float | None],
+    layout: dict,
 ) -> tuple[dict, str]:
-    """Build the per-sequence table data dict and HTML table string.
-
-    Parameters
-    ----------
-    pred_fields : list
-        Ordered list of prediction field names.
-    metric_names : list
-        Ordered list of metric group names.
-    metric_cols : dict
-        Mapping from metric name to its column names.
-    sequences : list
-        Sorted list of all sequence names.
-    dfs : dict
-        Nested data dict: ``{pred_field: {metric_name: df}}``.
-
-    Returns:
-    -------
-    tuple[dict, str]
-        ``(table_data, table_html)`` where *table_data* is used for JS diff
-        computation and *table_html* is the rendered ``<table>`` HTML.
-    """
+    """Build the per-sequence table data dict and HTML table string."""
     table_data = {
         pf: {
             mn: {
@@ -440,29 +494,69 @@ def _build_table_html(
         }
         for pf in pred_fields
     }
-    show_diff = len(pred_fields) >= 2  # noqa: PLR2004
-    pf_idx = {pf: i for i, pf in enumerate(pred_fields)}
-    n_cols_per_model = sum(len(metric_cols[mn]) for mn in metric_names)
-    pf_mn_col = [
-        (pf, mn, col)
-        for pf in pred_fields
-        for mn in metric_names
-        for col in metric_cols[mn]
-    ]
-    mn_col = [(mn, col) for mn in metric_names for col in metric_cols[mn]]
     table_html = _assemble_html_table(
+        sequences,
+        dfs,
+        summary,
+        layout,
+        pred_fields=pred_fields,
+        metric_names=metric_names,
+        metric_cols=metric_cols,
+    )
+    return table_data, table_html
+
+
+def _comparison_sections(dfs: dict) -> dict:
+    """Compute every HTML fragment and JSON payload for the comparison report."""
+    pred_fields = list(dfs.keys())
+    metric_names = list(next(iter(dfs.values())).keys())
+    sequences = sorted(
+        set.intersection(
+            *[
+                set(pf_val[mn_key]["sequence"])
+                for pf_val in dfs.values()
+                for mn_key in metric_names
+            ]
+        )
+        - {OVERALL_LABEL}
+    )
+    metric_cols = {
+        m: [c for c in next(iter(dfs.values()))[m].columns if c != "sequence"]
+        for m in metric_names
+    }
+    color_map = {
+        pf: _MODEL_COLORS[i % len(_MODEL_COLORS)] for i, pf in enumerate(pred_fields)
+    }
+    summary = _summary_values(pred_fields, metric_names, metric_cols, dfs)
+    layout = _table_layout(pred_fields, metric_names, metric_cols)
+    chart_data, checkboxes_html, tab_buttons, chart_grids = _build_chart_section(
+        pred_fields, metric_names, metric_cols, summary, color_map
+    )
+    table_data, table_html = _build_table_html(
         pred_fields,
         metric_names,
         metric_cols,
         sequences,
         dfs,
-        show_diff=show_diff,
-        pf_idx=pf_idx,
-        n_cols_per_model=n_cols_per_model,
-        pf_mn_col=pf_mn_col,
-        mn_col=mn_col,
+        summary=summary,
+        layout=layout,
     )
-    return table_data, table_html
+    return {
+        "pred_fields": pred_fields,
+        "metric_names": metric_names,
+        "sequences": sequences,
+        "metric_cols": metric_cols,
+        "color_map": color_map,
+        "overall_data": _overall_data_from_summary(
+            summary, pred_fields, metric_names, metric_cols
+        ),
+        "chart_data": chart_data,
+        "checkboxes_html": checkboxes_html,
+        "tab_buttons": tab_buttons,
+        "chart_grids": chart_grids,
+        "table_data": table_data,
+        "table_html": table_html,
+    }
 
 
 def build_comparison_html(dfs: dict) -> str:
@@ -487,59 +581,23 @@ def build_comparison_html(dfs: dict) -> str:
     if not dfs:
         raise ValueError("dfs must contain at least one element")
 
-    pred_fields = list(dfs.keys())
-    metric_names = list(next(iter(dfs.values())).keys())
-    # The pooled OVERALL row is rendered as the summary row, not as a per-sequence
-    # row, so exclude it from the sequence list used for the body and charts.
-    sequences = sorted(
-        set.intersection(
-            *[
-                set(pf_val[mn_key]["sequence"])
-                for pf_val in dfs.values()
-                for mn_key in metric_names
-            ]
-        )
-        - {OVERALL_LABEL}
-    )
-    metric_cols = {
-        m: [c for c in next(iter(dfs.values()))[m].columns if c != "sequence"]
-        for m in metric_names
-    }
-    color_map = {
-        pf: _MODEL_COLORS[i % len(_MODEL_COLORS)] for i, pf in enumerate(pred_fields)
-    }
-    # Summary-row values keyed for client-side diff (Δ) computation. Uses the
-    # same aggregation as the rendered summary row (_agg) so the mean fallback
-    # for legacy inputs without an OVERALL row stays consistent.
-    overall_data = {
-        pf: {
-            mn: {col: _round_or_none(_agg(dfs[pf][mn], col)) for col in metric_cols[mn]}
-            for mn in metric_names
-        }
-        for pf in pred_fields
-    }
-    chart_data, checkboxes_html, tab_buttons, chart_grids = _build_chart_section(
-        pred_fields, metric_names, metric_cols, dfs, color_map
-    )
-    table_data, table_html = _build_table_html(
-        pred_fields, metric_names, metric_cols, sequences, dfs
-    )
+    parts = _comparison_sections(dfs)
     template = (pathlib.Path(__file__).parent / "comparison_report.html").read_text(
         encoding="utf-8"
     )
 
     return (
         template.replace("__SUM_METRICS__", json.dumps(sorted(_SUM_METRICS)))
-        .replace("__CHART_DATA__", json.dumps(chart_data))
-        .replace("__OVERALL_DATA__", json.dumps(overall_data))
-        .replace("__TABLE_DATA__", json.dumps(table_data))
-        .replace("__METRIC_COLS__", json.dumps(metric_cols))
-        .replace("__SEQUENCES__", json.dumps(sequences))
-        .replace("__PRED_FIELDS__", json.dumps(pred_fields))
-        .replace("__METRIC_NAMES__", json.dumps(metric_names))
-        .replace("__COLOR_MAP__", json.dumps(color_map))
-        .replace("__CHECKBOXES_HTML__", checkboxes_html)
-        .replace("__TAB_BUTTONS__", tab_buttons)
-        .replace("__CHART_GRIDS__", chart_grids)
-        .replace("__TABLE_HTML__", table_html)
+        .replace("__CHART_DATA__", json.dumps(parts["chart_data"]))
+        .replace("__OVERALL_DATA__", json.dumps(parts["overall_data"]))
+        .replace("__TABLE_DATA__", json.dumps(parts["table_data"]))
+        .replace("__METRIC_COLS__", json.dumps(parts["metric_cols"]))
+        .replace("__SEQUENCES__", json.dumps(parts["sequences"]))
+        .replace("__PRED_FIELDS__", json.dumps(parts["pred_fields"]))
+        .replace("__METRIC_NAMES__", json.dumps(parts["metric_names"]))
+        .replace("__COLOR_MAP__", json.dumps(parts["color_map"]))
+        .replace("__CHECKBOXES_HTML__", parts["checkboxes_html"])
+        .replace("__TAB_BUTTONS__", parts["tab_buttons"])
+        .replace("__CHART_GRIDS__", parts["chart_grids"])
+        .replace("__TABLE_HTML__", parts["table_html"])
     )

--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -14,6 +14,9 @@ RATIO_METRICS = ("mota", "motp", "idf1", "idp", "idr", "precision", "recall")
 class TrackingMetrics:
     """MOT metrics wrapper around ``motmetrics`` with per-sequence accumulators."""
 
+    #: ``compute(list)`` returns motmetrics-style ``{metric: {seq: val, …}}``.
+    RESULT_LAYOUT = "nested"
+
     def __init__(self, **kwargs: object) -> None:
         """Initialise accumulators and defaults; extra kwargs become attributes."""
         self.accumulators = {}

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -864,7 +864,7 @@ def get_sequence_info(
     return sequence_info
 
 
-def _scale_metric_row(flat_result: dict) -> dict:
+def _scale_metric_row(flat_result: dict, *, layout: str) -> dict:
     """Apply metric-specific scaling to a flat ``{metric: scalar}`` result.
 
     TrackingMetrics: ``mota`` is scaled x100 and ``motp`` is converted to
@@ -874,11 +874,12 @@ def _scale_metric_row(flat_result: dict) -> dict:
 
     Args:
         flat_result: Mapping from metric name to a single scalar value.
+        layout: ``"flat"`` for HOTA-style results, ``"nested"`` for MOT.
 
     Returns:
         New dict with scaling applied.
     """
-    if "hota" in flat_result:
+    if layout == "flat":
         return {
             k: (v if k == "num_unique_objects" else v * 100)
             for k, v in flat_result.items()
@@ -892,33 +893,41 @@ def _scale_metric_row(flat_result: dict) -> dict:
 def _flatten_result(result: dict, key: str | None) -> dict:
     """Flatten a ``compute()`` result to a flat ``{metric: scalar}`` mapping.
 
-    HOTAMetrics already returns flat scalars. TrackingMetrics returns
-    ``{metric: {name: scalar}}`` (a ``motmetrics`` summary): *key* selects which
-    inner entry to take — ``OVERALL_LABEL`` for the pooled row, or ``None`` to
-    take the only entry of a single-sequence result.
+    Nested motmetrics-style results (TrackingMetrics and HOTA ``compute_many``)
+    map *key* to each metric's inner entry — ``OVERALL_LABEL`` for the pooled
+    row, or a sequence name for a per-sequence row. Flat HOTA single-sequence
+    results are returned unchanged.
 
     Args:
-        result: Raw dict returned by ``metrics.compute(...)``.
-        key: Inner key to select for TrackingMetrics results, or ``None``.
+        result: Raw dict returned by ``metrics.compute(...)`` or
+            ``metrics.compute_many(...)``.
+        key: Inner key to select for nested results, or ``None`` for flat.
 
     Returns:
         Flat ``{metric: scalar}`` dict.
     """
-    if "hota" in result:
-        return result
     if key is None:
-        return {k: next(iter(v.values())) for k, v in result.items()}
+        sample = next(iter(result.values()))
+        if isinstance(sample, dict):
+            return {k: next(iter(v.values())) for k, v in result.items()}
+        return result
     return {k: v[key] for k, v in result.items()}
+
+
+def _compute_table_bundle(metrics: object, sequence_list: list) -> dict:
+    """Return one nested result dict covering every table row."""
+    layout = getattr(metrics, "RESULT_LAYOUT", "nested")
+    if layout == "flat":
+        return metrics.compute_many(sequence_list)  # type: ignore[attr-defined]
+    return metrics.compute(sequence=sequence_list)  # type: ignore[attr-defined]
 
 
 def results_to_df(metrics: object, sequence_list: list | None = None) -> pd.DataFrame:
     """Convert TrackingMetrics or HOTAMetrics results to a DataFrame.
 
-    For TrackingMetrics, one ``compute(sequence_list)`` call returns all
-    per-sequence rows and the OVERALL row. For HOTAMetrics, per-sequence calls
-    are issued individually (HOTA pools internally; no per-sequence breakdown
-    from a list call). Appends a pooled OVERALL row — the MOT-standard
-    dataset-level score, not a mean of per-sequence values.
+    One batched ``compute()`` / ``compute_many()`` call returns all per-sequence
+    rows and the pooled OVERALL row. Appends a pooled OVERALL row — the
+    MOT-standard dataset-level score, not a mean of per-sequence values.
 
     Args:
         metrics: Fitted metric instance with ``accumulators`` and ``compute()``.
@@ -933,27 +942,18 @@ def results_to_df(metrics: object, sequence_list: list | None = None) -> pd.Data
     if not sequence_list:
         return pd.DataFrame()
 
-    overall = metrics.compute(sequence=sequence_list)  # type: ignore[attr-defined]
+    layout = getattr(metrics, "RESULT_LAYOUT", "nested")
+    bundle = _compute_table_bundle(metrics, sequence_list)
     rows = []
-
-    if "hota" not in overall:
-        for sequence in sequence_list:
-            row = _scale_metric_row(_flatten_result(overall, key=sequence))
-            row["sequence"] = sequence
-            rows.append(row)
-        row = _scale_metric_row(_flatten_result(overall, key=OVERALL_LABEL))
-        row["sequence"] = OVERALL_LABEL
+    for sequence in sequence_list:
+        row = _scale_metric_row(_flatten_result(bundle, key=sequence), layout=layout)
+        row["sequence"] = sequence
         rows.append(row)
-    else:
-        for sequence in sequence_list:
-            result = metrics.compute(sequence=sequence)  # type: ignore[attr-defined]
-            row = _scale_metric_row(_flatten_result(result, key=None))
-            row["sequence"] = sequence
-            rows.append(row)
-        if overall:
-            row = _scale_metric_row(_flatten_result(overall, key=None))
-            row["sequence"] = OVERALL_LABEL
-            rows.append(row)
+    row = _scale_metric_row(
+        _flatten_result(bundle, key=OVERALL_LABEL), layout=layout
+    )
+    row["sequence"] = OVERALL_LABEL
+    rows.append(row)
 
     return pd.DataFrame(rows)
 

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -949,9 +949,7 @@ def results_to_df(metrics: object, sequence_list: list | None = None) -> pd.Data
         row = _scale_metric_row(_flatten_result(bundle, key=sequence), layout=layout)
         row["sequence"] = sequence
         rows.append(row)
-    row = _scale_metric_row(
-        _flatten_result(bundle, key=OVERALL_LABEL), layout=layout
-    )
+    row = _scale_metric_row(_flatten_result(bundle, key=OVERALL_LABEL), layout=layout)
     row["sequence"] = OVERALL_LABEL
     rows.append(row)
 

--- a/tests/tracking/test_hota.py
+++ b/tests/tracking/test_hota.py
@@ -245,3 +245,11 @@ class TestHOTASubsetPooling:
         # A duplicate name would pool the same accumulator twice and skew scores.
         with pytest.raises(KeyError, match="Duplicate sequence"):
             self.m.compute(["A", "A"])
+
+    def test_compute_many_matches_single_calls(self):
+        bundle = self.m.compute_many(["A", "B"])
+        assert bundle["hota"]["A"] == pytest.approx(self.m.compute("A")["hota"])
+        assert bundle["hota"]["B"] == pytest.approx(self.m.compute("B")["hota"])
+        assert bundle["hota"]["OVERALL"] == pytest.approx(
+            self.m.compute(["A", "B"])["hota"]
+        )

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -227,17 +227,16 @@ def test_sequence_skipped_logs_all_pred_fields_when_one_missing():
 def test_results_to_df_formats_hota_and_tracking_outputs():
     class _HotaResults:
         accumulators: ClassVar = {"seq-1": None}
+        RESULT_LAYOUT = "flat"
 
-        def compute(self, sequence=None):
-            # str (per-seq), list (pooled), and None all accepted; the single-seq
-            # fake returns the same flat scalars for each.
-            assert sequence in ("seq-1", ["seq-1"], None)
+        def compute_many(self, sequence_list):
+            assert sequence_list == ["seq-1"]
             return {
-                "hota": 0.5,
-                "deta": 0.75,
-                "assa": 0.25,
-                "loca": 1.0,
-                "num_unique_objects": 2,
+                "hota": {"seq-1": 0.5, "OVERALL": 0.5},
+                "deta": {"seq-1": 0.75, "OVERALL": 0.75},
+                "assa": {"seq-1": 0.25, "OVERALL": 0.25},
+                "loca": {"seq-1": 1.0, "OVERALL": 1.0},
+                "num_unique_objects": {"seq-1": 2, "OVERALL": 2},
             }
 
     hota_df = utils.hota_results_to_df(_HotaResults())
@@ -252,6 +251,7 @@ def test_results_to_df_formats_hota_and_tracking_outputs():
 
     class _TrackingResults:
         accumulators: ClassVar = {"seq-1": None}
+        RESULT_LAYOUT = "nested"
 
         def compute(self, sequence=None):
             # Pooled calls (list/None) carry an explicit OVERALL entry whose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

This PR finishes the tracking refactor backlog: HOTA table export now uses one batched call instead of N+1 `compute()` invocations, report aggregation runs once for charts and summary rows, and pylint passes without raising `max-locals`.

## Why?

The previous pass relaxed pylint limits instead of simplifying the code. Metric detection via `"hota" in result` was fragile, and the report builder repeated the same triple-nested loops and `_agg` scans in multiple places.

## How?

| Area | Change |
|------|--------|
| **HOTA batching** | `HOTAMetrics.compute_many()` returns motmetrics-style `{metric: {seq, OVERALL}}`; `results_to_df` uses `_compute_table_bundle()` for both metric types |
| **Type detection** | `RESULT_LAYOUT` class attribute (`"nested"` / `"flat"`) replaces `"hota" in result` duck-typing |
| **Report loops** | `itertools.chain.from_iterable` + `product` via `_iter_pf_mn_col` / `_iter_mn_col`; shared `_summary_values()` feeds charts, overall data, and table summary row |
| **Pylint** | HTML assembly split into small helpers + `_comparison_sections()`; `max-locals=20` reverted |
| **HOTA internals** | `_aggregate_over_thresholds` uses `zip(*rows)` transpose instead of four accumulator lists |

## Testing

<!-- To be filled in manually. -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8732f8f-3852-472a-9a26-8020ac144a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8732f8f-3852-472a-9a26-8020ac144a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

