### PR TITLE
fix(tracking): 2-D empty MOT arrays prevent IndexError on GT-only sequences

### DIFF
--- a/seametrics/tracking/comparison_report.html
+++ b/seametrics/tracking/comparison_report.html
@@ -105,32 +105,55 @@
     }
   }
 
+  function fmtVal(v) {
+    return (v == null || Number.isNaN(v)) ? "" : v.toFixed(2);
+  }
+
+  function fmtDelta(v) {
+    if (v == null || Number.isNaN(v)) return "";
+    return (v >= 0 ? "+" : "") + v.toFixed(2);
+  }
+
   function updateDiff() {
     const pfA = document.getElementById("diff-a")?.value;
-    const pfB = document.getElementById("diff-b")?.value;
-    if (!pfA || !pfB) return;
+    const pfB = document.getElementById("diff-b")?.value || null;
 
-    const idxA = String(predFields.indexOf(pfA));
-    const idxB = String(predFields.indexOf(pfB));
+    const headerA = document.getElementById("model-header-a");
+    const headerB = document.getElementById("model-header-b");
+    if (headerA) headerA.textContent = pfA || "—";
+    if (headerB) headerB.textContent = pfB || "—";
 
     const label = document.getElementById("diff-label");
-    if (label) label.textContent = `Δ (${pfB} − ${pfA})`;
+    if (label) label.textContent = pfB ? `Δ (${pfB} − ${pfA})` : "Δ";
 
-    // Show only the two selected models' columns, hide all others
-    document.querySelectorAll("[data-pf]").forEach(el => {
-      const show = el.dataset.pf === idxA || el.dataset.pf === idxB;
-      el.style.display = show ? "" : "none";
+    document.querySelectorAll('[data-slot="a"]').forEach(cell => {
+      const { mn, col, seq } = cell.dataset;
+      const src = seq
+        ? tableData[pfA]?.[mn]?.[col]?.[seq]
+        : overallData[pfA]?.[mn]?.[col];
+      cell.textContent = fmtVal(src);
+    });
+
+    document.querySelectorAll('[data-slot="b"]').forEach(cell => {
+      const { mn, col, seq } = cell.dataset;
+      if (!pfB) { cell.textContent = ""; return; }
+      const src = seq
+        ? tableData[pfB]?.[mn]?.[col]?.[seq]
+        : overallData[pfB]?.[mn]?.[col];
+      cell.textContent = fmtVal(src);
     });
 
     document.querySelectorAll("[data-diff]").forEach(cell => {
       const { mn, col, seq } = cell.dataset;
+      if (!pfB) { cell.textContent = ""; return; }
       const a = tableData[pfA]?.[mn]?.[col]?.[seq];
       const b = tableData[pfB]?.[mn]?.[col]?.[seq];
-      cell.textContent = (a == null || b == null) ? "" : ((b - a >= 0 ? "+" : "") + (b - a).toFixed(2));
+      cell.textContent = (a == null || b == null) ? "" : fmtDelta(b - a);
     });
 
     document.querySelectorAll("[data-diff-mean]").forEach(cell => {
       const { mn, col } = cell.dataset;
+      if (!pfB) { cell.textContent = ""; return; }
       if (sumMetrics.has(col)) {
         let totalA = 0, totalB = 0, hasData = false;
         for (const seq of sequences) {
@@ -139,16 +162,12 @@
           if (a != null && b != null) { totalA += a; totalB += b; hasData = true; }
         }
         if (!hasData) { cell.textContent = ""; return; }
-        const delta = totalB - totalA;
-        cell.textContent = (delta >= 0 ? "+" : "") + delta.toFixed(2);
+        cell.textContent = fmtDelta(totalB - totalA);
       } else {
-        // Ratio metrics: diff the pooled, dataset-level OVERALL values, matching
-        // the server-rendered summary row (not a mean of per-sequence deltas).
         const a = overallData[pfA]?.[mn]?.[col];
         const b = overallData[pfB]?.[mn]?.[col];
         if (a == null || b == null) { cell.textContent = ""; return; }
-        const delta = b - a;
-        cell.textContent = (delta >= 0 ? "+" : "") + delta.toFixed(2);
+        cell.textContent = fmtDelta(b - a);
       }
     });
   }

--- a/seametrics/tracking/hota.py
+++ b/seametrics/tracking/hota.py
@@ -185,10 +185,10 @@ class HOTAMetrics:
                 pred_off += int(pred[:, 1].max()) + 1
             frame_off += max_frame + 1
         pooled_gt = (
-            np.concatenate(gt_parts) if gt_parts else np.empty((0,), dtype=float)
+            np.concatenate(gt_parts) if gt_parts else np.empty((0, 10), dtype=float)
         )
         pooled_pred = (
-            np.concatenate(pred_parts) if pred_parts else np.empty((0,), dtype=float)
+            np.concatenate(pred_parts) if pred_parts else np.empty((0, 10), dtype=float)
         )
         return pooled_gt, pooled_pred
 

--- a/seametrics/tracking/report.py
+++ b/seametrics/tracking/report.py
@@ -99,129 +99,147 @@ def _summary_values(
     }
 
 
-def _sortable_headers(
-    pf_mn_col: list,
-    mn_col: list,
-    *,
-    show_diff: bool,
-    pf_idx: dict,
-    n_regular_cols: int,
-) -> str:
-    """Build sortable column header cells."""
-    headers = "".join(
-        f'<th class="sortable" data-label="{_h(col)}" data-pf="{pf_idx[pf]}"'
-        f' onclick="sortTable({i + 1})" title="Sort by {_h(col)}">{_h(col)}</th>'
-        for i, (pf, _mn, col) in enumerate(pf_mn_col)
+def _default_compare_pair(pred_fields: list) -> tuple[str, str | None]:
+    """Return initial A/B selection for the comparison table."""
+    pf_a = pred_fields[0]
+    pf_b = pred_fields[1] if len(pred_fields) >= 2 else None  # noqa: PLR2004
+    return pf_a, pf_b
+
+
+def _metric_group_header_block(metric_names: list, metric_cols: dict) -> str:
+    """Build one row of metric-group ``<th>`` cells (MOT, HOTA, …)."""
+    return "".join(
+        f'<th colspan="{len(metric_cols[mn])}" style="border-left:2px solid #0f3460;">'
+        f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
+        for mn in metric_names
     )
-    if show_diff:
-        headers += "".join(
+
+
+def _compare_slot_headers(
+    n_cols_per_model: int,
+    *,
+    name_a: str,
+    name_b: str,
+) -> str:
+    """Build top-row A / B / Δ model name headers."""
+    return (
+        f'<th colspan="{n_cols_per_model}" id="model-header-a"'
+        f' style="border-left:2px solid #e94560;">{_h(name_a)}</th>'
+        f'<th colspan="{n_cols_per_model}" id="model-header-b"'
+        f' style="border-left:2px solid #2a2a4a;">{_h(name_b)}</th>'
+        f'<th colspan="{n_cols_per_model}"'
+        f' style="border-left:2px solid #e94560;">'
+        f'<span id="diff-label">Δ</span></th>'
+    )
+
+
+def _sortable_headers(mn_col: list) -> str:
+    """Build sortable column header cells for A, B, and Δ blocks."""
+    headers = []
+    col_idx = 0
+    for _slot in ("a", "b"):
+        for _mn, col in mn_col:
+            col_idx += 1
+            headers.append(
+                f'<th class="sortable" data-label="{_h(col)}"'
+                f' onclick="sortTable({col_idx})" title="Sort by {_h(col)}">'
+                f"{_h(col)}</th>"
+            )
+    for _mn, col in mn_col:
+        col_idx += 1
+        headers.append(
             f'<th class="sortable" data-label="Δ {_h(col)}"'
-            f' onclick="sortTable({n_regular_cols + i + 1})"'
+            f' onclick="sortTable({col_idx})"'
             f' title="Sort by Δ {_h(col)}">Δ {_h(col)}</th>'
-            for i, (_mn, col) in enumerate(mn_col)
         )
-    return headers
+    return "".join(headers)
+
+
+def _slot_cell(
+    dfs: dict,
+    pf: str | None,
+    mn: str,
+    col: str,
+    seq: str,
+) -> str:
+    """Format one per-sequence metric cell for slot A or B."""
+    if pf is None:
+        return ""
+    return _fmt_cell(_cell_value(dfs, pf, mn, col, seq))
 
 
 def _sequence_rows(
     sequences: list,
-    pf_mn_col: list,
     mn_col: list,
     dfs: dict,
     *,
-    show_diff: bool,
-    pf_idx: dict,
+    pf_a: str,
+    pf_b: str | None,
 ) -> str:
-    """Build per-sequence table body rows."""
+    """Build per-sequence table body rows for the A/B comparison layout."""
     return "".join(
         "<tr><td>"
         + _h(seq)
         + "</td>"
         + "".join(
-            f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
-            f"{_fmt_cell(_cell_value(dfs, pf, mn, col, seq))}</td>"
-            for pf, mn, col in pf_mn_col
+            f'<td style="text-align:right;" data-slot="a"'
+            f' data-mn="{_h(mn)}" data-col="{_h(col)}" data-seq="{_h(seq)}">'
+            f"{_slot_cell(dfs, pf_a, mn, col, seq)}</td>"
+            for mn, col in mn_col
         )
-        + (
-            "".join(
-                f'<td style="text-align:right;" data-diff'
-                f' data-mn="{_h(mn)}" data-col="{_h(col)}"'
-                f' data-seq="{_h(seq)}"></td>'
-                for mn, col in mn_col
-            )
-            if show_diff
-            else ""
+        + "".join(
+            f'<td style="text-align:right;" data-slot="b"'
+            f' data-mn="{_h(mn)}" data-col="{_h(col)}" data-seq="{_h(seq)}">'
+            f"{_slot_cell(dfs, pf_b, mn, col, seq)}</td>"
+            for mn, col in mn_col
+        )
+        + "".join(
+            f'<td style="text-align:right;" data-diff'
+            f' data-mn="{_h(mn)}" data-col="{_h(col)}" data-seq="{_h(seq)}"></td>'
+            for mn, col in mn_col
         )
         + "</tr>"
         for seq in sequences
     )
 
 
+def _summary_slot_cell(
+    summary: dict[tuple[str, str, str], float | None],
+    pf: str | None,
+    mn: str,
+    col: str,
+) -> str:
+    """Format one summary-row cell for slot A or B."""
+    if pf is None:
+        return ""
+    val = summary.get((pf, mn, col))
+    return _fmt_cell(val) if val is not None else ""
+
+
 def _summary_cells(
-    pf_mn_col: list,
     mn_col: list,
     summary: dict[tuple[str, str, str], float | None],
     *,
-    show_diff: bool,
-    pf_idx: dict,
+    pf_a: str,
+    pf_b: str | None,
 ) -> str:
-    """Build summary-row metric cells."""
+    """Build summary-row metric cells for the A/B comparison layout."""
     cells = "".join(
-        f'<td style="text-align:right;" data-pf="{pf_idx[pf]}">'
-        f"{_fmt_cell(val) if (val := summary[pf, mn, col]) is not None else ''}</td>"
-        for pf, mn, col in pf_mn_col
+        f'<td style="text-align:right;" data-slot="a" data-mn="{_h(mn)}"'
+        f' data-col="{_h(col)}">{_summary_slot_cell(summary, pf_a, mn, col)}</td>'
+        for mn, col in mn_col
     )
-    if show_diff:
-        cells += "".join(
-            f'<td style="text-align:right;" data-diff-mean'
-            f' data-mn="{_h(mn)}" data-col="{_h(col)}"></td>'
-            for mn, col in mn_col
-        )
+    cells += "".join(
+        f'<td style="text-align:right;" data-slot="b" data-mn="{_h(mn)}"'
+        f' data-col="{_h(col)}">{_summary_slot_cell(summary, pf_b, mn, col)}</td>'
+        for mn, col in mn_col
+    )
+    cells += "".join(
+        f'<td style="text-align:right;" data-diff-mean'
+        f' data-mn="{_h(mn)}" data-col="{_h(col)}"></td>'
+        for mn, col in mn_col
+    )
     return cells
-
-
-def _pred_field_headers(
-    pred_fields: list, n_cols_per_model: int, pf_idx: dict, *, show_diff: bool
-) -> str:
-    """Build top-row model name headers."""
-    headers = "".join(
-        f'<th colspan="{n_cols_per_model}" data-pf="{pf_idx[pf]}"'
-        f' style="border-left:2px solid #e94560;">{_h(pf)}</th>'
-        for pf in pred_fields
-    )
-    if show_diff:
-        headers += (
-            f'<th colspan="{n_cols_per_model}"'
-            f' style="border-left:2px solid #e94560;">'
-            f'<span id="diff-label">Δ</span></th>'
-        )
-    return headers
-
-
-def _metric_name_headers(
-    pred_fields: list,
-    metric_names: list,
-    metric_cols: dict,
-    pf_idx: dict,
-    *,
-    show_diff: bool,
-) -> str:
-    """Build second-row metric group headers."""
-    headers = "".join(
-        f'<th colspan="{len(metric_cols[mn])}" data-pf="{pf_idx[pf]}"'
-        f' style="border-left:2px solid #0f3460;">'
-        f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
-        for pf in pred_fields
-        for mn in metric_names
-    )
-    if show_diff:
-        headers += "".join(
-            f'<th colspan="{len(metric_cols[mn])}"'
-            f' style="border-left:2px solid #0f3460;">'
-            f"{_h(_DISPLAY_NAME.get(mn, mn))}</th>"
-            for mn in metric_names
-        )
-    return headers
 
 
 def _cell_value(dfs: dict, pf: str, mn: str, col: str, seq: str) -> float:
@@ -234,15 +252,16 @@ def _fmt_cell(val: float) -> str:
     return "" if pd.isna(val) else f"{val:.2f}"
 
 
-def _build_diff_controls(pred_fields: list, show_diff: bool) -> str:
-    """Build the diff model-selector HTML, or return empty string."""
-    if not show_diff:
-        return ""
+def _build_diff_controls(pred_fields: list) -> str:
+    """Build the A vs B field selectors above the comparison table."""
     opts_a = "".join(
-        f'<option value="{_h(pf)}">{_h(pf)}</option>' for pf in pred_fields
+        f'<option value="{_h(pf)}"{" selected" if i == 0 else ""}>{_h(pf)}</option>'
+        for i, pf in enumerate(pred_fields)
     )
-    opts_b = "".join(
-        f'<option value="{_h(pf)}" {"selected" if i == 1 else ""}>{_h(pf)}</option>'
+    none_selected = len(pred_fields) < 2  # noqa: PLR2004
+    opts_b = f'<option value=""{" selected" if none_selected else ""}>—</option>'
+    opts_b += "".join(
+        f'<option value="{_h(pf)}"{" selected" if i == 1 else ""}>{_h(pf)}</option>'
         for i, pf in enumerate(pred_fields)
     )
     return (
@@ -255,14 +274,12 @@ def _build_diff_controls(pred_fields: list, show_diff: bool) -> str:
     )
 
 
-def _table_layout(pred_fields: list, metric_names: list, metric_cols: dict) -> dict:
-    """Pre-compute table iteration order and diff-column flags."""
+def _table_layout(metric_names: list, metric_cols: dict) -> dict:
+    """Pre-compute table iteration order for the fixed A/B/Δ layout."""
+    mn_col = list(_iter_mn_col(metric_names, metric_cols))
     return {
-        "show_diff": len(pred_fields) >= 2,  # noqa: PLR2004
-        "pf_idx": {pf: i for i, pf in enumerate(pred_fields)},
+        "mn_col": mn_col,
         "n_cols_per_model": sum(len(metric_cols[mn]) for mn in metric_names),
-        "pf_mn_col": list(_iter_pf_mn_col(pred_fields, metric_names, metric_cols)),
-        "mn_col": list(_iter_mn_col(metric_names, metric_cols)),
     }
 
 
@@ -277,39 +294,25 @@ def _assemble_html_table(
     metric_cols: dict,
 ) -> str:
     """Assemble the full ``<table>`` HTML string from pre-computed layout values."""
-    pf_mn_col = layout["pf_mn_col"]
     mn_col = layout["mn_col"]
-    pf_idx = layout["pf_idx"]
-    show_diff = layout["show_diff"]
-    body_rows = _sequence_rows(
-        sequences, pf_mn_col, mn_col, dfs, show_diff=show_diff, pf_idx=pf_idx
-    )
-    summary_row = _summary_cells(
-        pf_mn_col, mn_col, summary, show_diff=show_diff, pf_idx=pf_idx
-    )
+    n_cols = layout["n_cols_per_model"]
+    pf_a, pf_b = _default_compare_pair(pred_fields)
+    group_hdr = _metric_group_header_block(metric_names, metric_cols)
+    body_rows = _sequence_rows(sequences, mn_col, dfs, pf_a=pf_a, pf_b=pf_b)
+    summary_row = _summary_cells(mn_col, summary, pf_a=pf_a, pf_b=pf_b)
     return (
-        _build_diff_controls(pred_fields, show_diff)
+        _build_diff_controls(pred_fields)
         + f"""<table id="seq-table">
     <thead>
       <tr><th rowspan="3">Sequence</th>{
-            _pred_field_headers(
-                pred_fields, layout["n_cols_per_model"], pf_idx, show_diff=show_diff
+            _compare_slot_headers(
+                n_cols,
+                name_a=pf_a,
+                name_b=pf_b or "—",
             )
         }</tr>
-      <tr>{
-            _metric_name_headers(
-                pred_fields, metric_names, metric_cols, pf_idx, show_diff=show_diff
-            )
-        }</tr>
-      <tr>{
-            _sortable_headers(
-                pf_mn_col,
-                mn_col,
-                show_diff=show_diff,
-                pf_idx=pf_idx,
-                n_regular_cols=len(pf_mn_col),
-            )
-        }</tr>
+      <tr>{group_hdr}{group_hdr}{group_hdr}</tr>
+      <tr>{_sortable_headers(mn_col)}</tr>
     </thead>
     <tbody>
       {body_rows}
@@ -444,7 +447,7 @@ def _comparison_sections(dfs: dict) -> dict:
         pf: _MODEL_COLORS[i % len(_MODEL_COLORS)] for i, pf in enumerate(pred_fields)
     }
     summary = _summary_values(pred_fields, metric_names, metric_cols, dfs)
-    layout = _table_layout(pred_fields, metric_names, metric_cols)
+    layout = _table_layout(metric_names, metric_cols)
     chart_data, checkboxes_html, tab_buttons, chart_grids = _build_chart_section(
         pred_fields, metric_names, metric_cols, summary, color_map
     )

--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -28,7 +28,9 @@ class TrackingMetrics:
 
     def update(self, gt: np.ndarray, pred: np.ndarray, sequence_name: str) -> None:
         """Build a MOTAccumulator for *sequence_name* from (gt, pred) arrays."""
-        num_frames = max(gt[:, 0].max(), pred[:, 0].max()) + 1
+        gt_max = int(gt[:, 0].max()) if len(gt) > 0 else 0
+        pred_max = int(pred[:, 0].max()) if len(pred) > 0 else 0
+        num_frames = max(gt_max, pred_max) + 1
         acc = mm.MOTAccumulator(auto_id=True)
 
         for i in range(1, int(num_frames)):

--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -28,6 +28,10 @@ class TrackingMetrics:
 
     def update(self, gt: np.ndarray, pred: np.ndarray, sequence_name: str) -> None:
         """Build a MOTAccumulator for *sequence_name* from (gt, pred) arrays."""
+        if len(gt) == 0 and gt.ndim == 1:
+            gt = np.empty((0, 10))
+        if len(pred) == 0 and pred.ndim == 1:
+            pred = np.empty((0, 10))
         gt_max = int(gt[:, 0].max()) if len(gt) > 0 else 0
         pred_max = int(pred[:, 0].max()) if len(pred) > 0 else 0
         num_frames = max(gt_max, pred_max) + 1

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -166,7 +166,9 @@ def prepare_data_for_det_metrics(  # noqa: C901
                         ]
                     )
 
-        return np.array(target), np.array(preds)
+        # Always return 2-D MOT arrays so downstream code can index ``[:, col]``
+        # even when one side has zero detections.
+        return np.array(target).reshape(-1, 10), np.array(preds).reshape(-1, 10)
 
     def _validate_arrays(data: list | None, data_type: str) -> list:
         """Validate and normalise per-frame annotation arrays.
@@ -817,10 +819,19 @@ def compute_all_metrics_by_sequence(
         for instance in pf_instances.values()
         for seq in instance.failed_sequences
     }
+    failure_reasons = {
+        seq: next(
+            inst.failed_sequences[seq]
+            for pf_instances in instances.values()
+            for inst in pf_instances.values()
+            if seq in inst.failed_sequences
+        )
+        for seq in all_failed
+    }
     for pf_instances in instances.values():
         for instance in pf_instances.values():
             for seq in all_failed - set(instance.failed_sequences):
-                instance.log_failed_sequence(seq, [], [], exc=None)
+                instance.failed_sequences[seq] = failure_reasons[seq]
 
     return instances
 

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -51,14 +51,14 @@ def failed_sequence_reason(
     Returns:
         A short explanation string.
     """
+    if exc is not None:
+        return f"{type(exc).__name__}: {exc}"
     if len(gt) == 0 and len(pred) == 0:
         return "No ground truth and no predictions"
     if len(gt) == 0:
         return "No ground truth"
     if len(pred) == 0:
         return "No predictions"
-    if exc is not None:
-        return f"{type(exc).__name__}: {exc}"
     return "Missing IDs from GT or Pred"
 
 
@@ -593,15 +593,18 @@ def compute_metrics_by_sequence(
     return metric
 
 
-def _has_keyframes(seq_view: fo.DatasetView, pred_field: str) -> bool:
-    """Return True if any frame in *seq_view* has keyframe data for *pred_field*.
+def _field_exists(seq_view: fo.DatasetView, field: str) -> bool:
+    """Return True when *field* is defined on the sequence view.
+
+    A field may exist but carry empty detections on every frame; that still
+    counts as present and the sequence should be evaluated.
 
     Args:
         seq_view: FiftyOne view for a single sequence.
-        pred_field: Prediction field name to check.
+        field: Frame field name (e.g. a prediction or ground-truth field).
 
     Returns:
-        True if at least one keyframe value is truthy; False otherwise.
+        True when the field exists on the view schema.
 
     Raises:
         ImportError: If ``fiftyone`` is not installed.
@@ -613,32 +616,35 @@ def _has_keyframes(seq_view: fo.DatasetView, pred_field: str) -> bool:
         if seq_view.media_type == "group"
         else seq_view
     )
-    try:
-        kf_vals = video_view.values(f"frames[].{pred_field}.keyframe")
-        return any(kf for kf in kf_vals if kf)
-    except (ValueError, AttributeError, RuntimeError, TypeError, KeyError):
-        return False
+    if video_view.media_type == "video":
+        return video_view.has_frame_field(field)
+    if video_view.media_type == "image":
+        return video_view.has_field(field)
+    return False
 
 
 def _filter_valid_sequences(
     sequence_list: list,
     view: fo.DatasetView,
+    gt_field: str,
     pred_fields: list,
     instances: dict,
 ) -> list:
-    """Validate keyframe availability and return sequences that have all fields.
+    """Validate field availability and return sequences ready for evaluation.
 
-    Sequences missing keyframes for any prediction field are logged as failed
-    on every metric instance and excluded from the returned list.
+    Sequences where the ground-truth or any prediction field is absent from the
+    schema are logged as failed and excluded. Fields that exist but contain
+    only empty detections are kept — metrics run on empty (gt, pred) arrays.
 
     Args:
         sequence_list: Candidate sequence names.
         view: FiftyOne dataset view used to match individual sequences.
+        gt_field: Ground-truth field name.
         pred_fields: Prediction field names to validate.
         instances: Nested dict ``{pred_field: {metric_name: metric_instance}}``.
 
     Returns:
-        List of sequence names where all prediction fields have keyframe data.
+        List of sequence names where all required fields exist.
 
     Raises:
         ImportError: If ``fiftyone`` is not installed.
@@ -648,9 +654,13 @@ def _filter_valid_sequences(
     valid = []
     for sequence_name in tqdm(sequence_list, desc="Validating sequences"):
         sequence_view = view.match(F("sequence") == sequence_name)
-        missing = [pf for pf in pred_fields if not _has_keyframes(sequence_view, pf)]
+        missing = [
+            name
+            for name in [gt_field, *pred_fields]
+            if not _field_exists(sequence_view, name)
+        ]
         if missing:
-            exc = ValueError(f"No keyframe data for: {missing}")
+            exc = ValueError(f"Field not found: {missing}")
             for pf in pred_fields:
                 for instance in instances[pf].values():
                     instance.log_failed_sequence(sequence_name, [], [], exc=exc)
@@ -755,7 +765,9 @@ def compute_all_metrics_by_sequence(
         pred_field: {fn.__name__: fn(**kwargs) for fn, kwargs in metrics}
         for pred_field in pred_fields
     }
-    valid_sequences = _filter_valid_sequences(resolved, view, pred_fields, instances)
+    valid_sequences = _filter_valid_sequences(
+        resolved, view, gt_field, pred_fields, instances
+    )
     _run_metric_updates(valid_sequences, view, pred_fields, gt_field, instances)
 
     # Ensure consistent results: any sequence that failed for one pred_field is

--- a/seametrics/tracking/utils.py
+++ b/seametrics/tracking/utils.py
@@ -593,6 +593,33 @@ def compute_metrics_by_sequence(
     return metric
 
 
+def _has_keyframes(seq_view: fo.DatasetView, pred_field: str) -> bool:
+    """Return True if any frame in *seq_view* has a truthy keyframe for *pred_field*.
+
+    Args:
+        seq_view: FiftyOne view for a single sequence.
+        pred_field: Prediction field name to check.
+
+    Returns:
+        True if at least one keyframe value is truthy; False otherwise.
+
+    Raises:
+        ImportError: If ``fiftyone`` is not installed.
+    """
+    if not _FIFTYONE_AVAILABLE:
+        raise ImportError("fiftyone is required for this function")
+    video_view = (
+        seq_view.select_group_slices(seq_view.default_group_slice)
+        if seq_view.media_type == "group"
+        else seq_view
+    )
+    try:
+        kf_vals = video_view.values(f"frames[].{pred_field}.keyframe")
+        return any(kf for kf in kf_vals if kf)
+    except (ValueError, AttributeError, RuntimeError, TypeError, KeyError):
+        return False
+
+
 def _field_exists(seq_view: fo.DatasetView, field: str) -> bool:
     """Return True when *field* is defined on the sequence view.
 
@@ -630,11 +657,12 @@ def _filter_valid_sequences(
     pred_fields: list,
     instances: dict,
 ) -> list:
-    """Validate field availability and return sequences ready for evaluation.
+    """Validate fields and keyframes before evaluating sequences.
 
-    Sequences where the ground-truth or any prediction field is absent from the
-    schema are logged as failed and excluded. Fields that exist but contain
-    only empty detections are kept — metrics run on empty (gt, pred) arrays.
+    Sequences are excluded when a required field is absent from the schema
+    (``Field not found``) or when a prediction field has no truthy keyframes
+    (``No keyframe data``). Fields that exist with keyframes but empty
+    detections on those frames are kept and evaluated.
 
     Args:
         sequence_list: Candidate sequence names.
@@ -644,7 +672,7 @@ def _filter_valid_sequences(
         instances: Nested dict ``{pred_field: {metric_name: metric_instance}}``.
 
     Returns:
-        List of sequence names where all required fields exist.
+        List of sequence names passing field and keyframe checks.
 
     Raises:
         ImportError: If ``fiftyone`` is not installed.
@@ -661,6 +689,16 @@ def _filter_valid_sequences(
         ]
         if missing:
             exc = ValueError(f"Field not found: {missing}")
+        else:
+            no_keyframes = [
+                pf for pf in pred_fields if not _has_keyframes(sequence_view, pf)
+            ]
+            exc = (
+                ValueError(f"No keyframe data for: {no_keyframes}")
+                if no_keyframes
+                else None
+            )
+        if exc is not None:
             for pf in pred_fields:
                 for instance in instances[pf].values():
                     instance.log_failed_sequence(sequence_name, [], [], exc=exc)

--- a/tests/tracking/test_report.py
+++ b/tests/tracking/test_report.py
@@ -291,21 +291,26 @@ class TestCellValue:
 class TestBuildDiffControls:
     """Tests for _build_diff_controls."""
 
-    def test_disabled_returns_empty_string(self):
-        assert not _build_diff_controls(["a", "b"], False)
-
-    def test_enabled_contains_pred_fields(self):
-        html = _build_diff_controls(["model_a", "model_b"], True)
-        assert "model_a" in html
-        assert "model_b" in html
-
-    def test_enabled_contains_select_elements(self):
-        html = _build_diff_controls(["model_a", "model_b"], True)
+    def test_always_contains_select_elements(self):
+        html = _build_diff_controls(["model_a"])
         assert html.count("<select") == 2
 
-    def test_second_option_selected(self):
-        html = _build_diff_controls(["model_a", "model_b"], True)
-        assert "selected" in html
+    def test_single_field_defaults_b_to_none(self):
+        html = _build_diff_controls(["model_a"])
+        assert 'id="diff-a"' in html
+        assert "<option value=\"\" selected>—</option>" in html
+
+    def test_two_fields_defaults_a_and_b(self):
+        html = _build_diff_controls(["model_a", "model_b"])
+        assert "model_a" in html
+        assert "model_b" in html
+        assert 'value="model_a" selected' in html
+        assert 'value="model_b" selected' in html
+
+    def test_many_fields_lists_all_in_both_dropdowns(self):
+        html = _build_diff_controls(["f0", "f1", "f2", "f3"])
+        assert html.count('value="f0"') == 2
+        assert html.count('value="f3"') == 2
 
 
 # ---------------------------------------------------------------------------
@@ -343,10 +348,26 @@ class TestBuildComparisonHtml:
         result = build_comparison_html(_two_model_dfs())
         assert "diff-a" in result
 
-    def test_single_model_no_diff_select(self):
-        """With one model, the diff <select> widgets must not be rendered."""
+    def test_single_model_has_compare_dropdowns(self):
+        """One field still shows the A vs B table with B defaulting to —."""
         result = build_comparison_html(_one_model_dfs())
-        assert '<select id="diff-a"' not in result
+        assert 'id="diff-a"' in result
+        assert 'id="diff-b"' in result
+        assert 'id="model-header-a"' in result
+        assert 'id="model-header-b"' in result
+        assert 'data-slot="a"' in result
+        assert 'data-slot="b"' in result
+
+    def test_table_is_fixed_ab_layout_not_all_models(self):
+        """Table renders two metric slots, not one column block per model."""
+        many = {
+            f"model_{i}": {"TrackingMetrics": _mot_df(("s1",))}
+            for i in range(4)
+        }
+        result = build_comparison_html(many)
+        assert result.count('data-slot="a"') > 0
+        assert result.count('data-slot="b"') > 0
+        assert 'data-pf="' not in result
 
     def test_html_contains_table_element(self):
         result = build_comparison_html(_two_model_dfs())

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -93,6 +93,23 @@ class TestNoPredictions:
         assert _scalar(r, "num_false_positives") == 1
 
 
+class TestEmptyPredictions:
+    """Fully empty pred array with GT present should still compute."""
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+        )
+        pred = np.empty((0, 7))
+        self.m = TrackingMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_all_gt_missed(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_misses") == 2
+
+
 # ---------------------------------------------------------------------------
 # ID switch
 # ---------------------------------------------------------------------------
@@ -244,6 +261,12 @@ class TestLogFailedSequence:
         m = TrackingMetrics()
         m.log_failed_sequence("s", [], [])
         assert m.failed_sequences["s"] == "No ground truth and no predictions"
+
+    def test_exception_takes_priority_over_empty_arrays(self):
+        m = TrackingMetrics()
+        exc = ValueError("Field not found: ['pred_x']")
+        m.log_failed_sequence("s", [], [], exc=exc)
+        assert m.failed_sequences["s"] == "ValueError: Field not found: ['pred_x']"
 
     def test_no_gt(self):
         m = TrackingMetrics()

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -282,3 +282,18 @@ class TestLogFailedSequence:
         m = TrackingMetrics()
         m.log_failed_sequence("s", [1], [1])
         assert m.failed_sequences["s"] == "Missing IDs from GT or Pred"
+
+    def test_update_gt_only_empty_pred_1d(self):
+        """1-D empty pred arrays must not crash update (legacy shape guard)."""
+        m = TrackingMetrics()
+        gt = np.array([[1, 1, 0, 0, 10, 10, 1, -1, -1, -1]])
+        pred = np.array([])
+        m.update(gt, pred, "s")
+        assert "s" in m.accumulators
+
+    def test_update_gt_only_empty_pred_2d(self):
+        m = TrackingMetrics()
+        gt = np.array([[1, 1, 0, 0, 10, 10, 1, -1, -1, -1]])
+        pred = np.empty((0, 10))
+        m.update(gt, pred, "s")
+        assert "s" in m.accumulators

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -154,8 +154,43 @@ def test_sequence_skipped_when_pred_field_missing():
     assert "missing_pred" in str(exc)
 
 
-def test_sequence_processed_when_field_exists_but_detections_empty():
-    """Empty detections on an existing field should still be evaluated."""
+def test_sequence_skipped_when_no_true_keyframes():
+    """Sequences without any truthy keyframes are excluded."""
+    failures = []
+
+    class _CapturingMetric:
+        def __init__(self) -> None:
+            self.failed_sequences: dict = {}
+
+        def update(self, _gt, _pred, _seq):
+            raise AssertionError("should not be called")
+
+        def log_failed_sequence(self, seq, _gt, _pred, **_kwargs: object):
+            failures.append((seq, _kwargs.get("exc")))
+            self.failed_sequences[seq] = str(_kwargs.get("exc"))
+
+    class _NoKeyframeView(_FakeVideoView):
+        def values(self, field):
+            if "keyframe" in field:
+                return [False, False, False]
+            return super().values(field)
+
+    with _fo_patch():
+        utils.compute_all_metrics_by_sequence(
+            view=_NoKeyframeView(),
+            gt_field="gt",
+            pred_fields=["pred"],
+            metrics=[(_CapturingMetric, {})],
+        )
+
+    assert len(failures) == 1
+    assert failures[0][0] == "seq-1"
+    assert "No keyframe data" in str(failures[0][1])
+    assert "pred" in str(failures[0][1])
+
+
+def test_sequence_processed_when_keyframes_exist_but_detections_empty():
+    """Empty detections on keyframe frames should still be evaluated."""
     updates = []
 
     class _CapturingMetric:
@@ -171,7 +206,7 @@ def test_sequence_processed_when_field_exists_but_detections_empty():
     class _EmptyDetectionsView(_FakeVideoView):
         def values(self, field):
             if "keyframe" in field:
-                return [False, False, False]
+                return [True, False, True]
             if "bounding_box" in field or "index" in field or "confidence" in field:
                 return [None, None, None]
             return super().values(field)

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -340,6 +340,36 @@ def test_results_to_df_rejects_overall_sequence_name():
 # ---------------------------------------------------------------------------
 
 
+def test_prepare_data_empty_returns_2d_arrays():
+    """Empty GT and pred must be (0, 10), not 1-D, for MOT indexing."""
+    gt, pred = utils.prepare_data_for_det_metrics(
+        gt_bboxes_per_frame=[],
+        gt_track_ids_per_frame=[],
+        dt_bboxes_per_frame=[],
+        dt_track_ids_per_frame=[],
+        dt_scores_per_frame=[],
+        img_w=100,
+        img_h=100,
+    )
+    assert gt.shape == (0, 10)
+    assert pred.shape == (0, 10)
+
+
+def test_prepare_data_gt_only_empty_pred_is_2d():
+    """GT-only sequences must not produce a 1-D empty pred array."""
+    gt, pred = utils.prepare_data_for_det_metrics(
+        gt_bboxes_per_frame=[[[0.1, 0.1, 0.2, 0.2]]],
+        gt_track_ids_per_frame=[[1]],
+        dt_bboxes_per_frame=[],
+        dt_track_ids_per_frame=[],
+        dt_scores_per_frame=[],
+        img_w=100,
+        img_h=100,
+    )
+    assert gt.shape == (1, 10)
+    assert pred.shape == (0, 10)
+
+
 def test_prepare_data_basic_single_frame():
     """One GT and one pred in one frame produce (1, 10) arrays each."""
     gt, pred = utils.prepare_data_for_det_metrics(
@@ -402,7 +432,7 @@ def test_prepare_data_none_track_id_skipped():
         img_w=100,
         img_h=100,
     )
-    assert gt.shape == (0,)
+    assert gt.shape == (0, 10)
     assert pred.shape == (1, 10)
 
 

--- a/tests/tracking/test_tracking_utils.py
+++ b/tests/tracking/test_tracking_utils.py
@@ -16,7 +16,7 @@ class _FakeVideoView:
         self.selected_fields = None
 
     def has_frame_field(self, field):
-        return field == "pred.keyframe" or field.startswith(
+        return field in {"gt", "pred"} or field == "pred.keyframe" or field.startswith(
             ("gt.", "pred.", "sequence")
         )
 
@@ -120,8 +120,8 @@ def test_compute_all_metrics_by_sequence_uses_group_slice_and_keyframes():
     assert pred[:, 6].tolist() == [0.9, 0.7]
 
 
-def test_sequence_skipped_when_keyframe_lookup_raises():
-    """_has_keyframes except branch: returns False when values() raises."""
+def test_sequence_skipped_when_pred_field_missing():
+    """Sequences are skipped only when a field is absent from the schema."""
     failures = []
 
     class _CapturingMetric:
@@ -135,63 +135,65 @@ def test_sequence_skipped_when_keyframe_lookup_raises():
             failures.append((seq, _kwargs.get("exc")))
             self.failed_sequences[seq] = str(_kwargs.get("exc"))
 
-    class _ErrorView(_FakeVideoView):
-        def values(self, field):
-            if "keyframe" in field:
-                raise RuntimeError("field not found")
-            return super().values(field)
+    class _MissingFieldView(_FakeVideoView):
+        def has_frame_field(self, field):
+            return field != "missing_pred"
 
     with _fo_patch():
         utils.compute_all_metrics_by_sequence(
-            view=_ErrorView(),
+            view=_MissingFieldView(),
             gt_field="gt",
-            pred_fields=["pred"],
+            pred_fields=["missing_pred"],
             metrics=[(_CapturingMetric, {})],
         )
 
     assert len(failures) == 1
     seq, exc = failures[0]
     assert seq == "seq-1"
-    assert "pred" in str(exc)
+    assert "Field not found" in str(exc)
+    assert "missing_pred" in str(exc)
 
 
-def test_sequence_skipped_when_no_true_keyframes():
-    """_has_keyframes returns False when all keyframe values are False."""
-    failures = []
+def test_sequence_processed_when_field_exists_but_detections_empty():
+    """Empty detections on an existing field should still be evaluated."""
+    updates = []
 
     class _CapturingMetric:
         def __init__(self) -> None:
             self.failed_sequences: dict = {}
 
-        def update(self, _gt, _pred, _seq):
-            raise AssertionError("should not be called")
+        def update(self, gt, pred, seq):
+            updates.append((gt.shape, pred.shape, seq))
 
-        def log_failed_sequence(self, seq, _gt, _pred, **_kwargs: object):
-            failures.append((seq, _kwargs.get("exc")))
-            self.failed_sequences[seq] = str(_kwargs.get("exc"))
+        def log_failed_sequence(self, *_args: object, **_kwargs: object):
+            raise AssertionError("unexpected failure")
 
-    class _NoKeyframeView(_FakeVideoView):
+    class _EmptyDetectionsView(_FakeVideoView):
         def values(self, field):
             if "keyframe" in field:
                 return [False, False, False]
+            if "bounding_box" in field or "index" in field or "confidence" in field:
+                return [None, None, None]
             return super().values(field)
 
     with _fo_patch():
         utils.compute_all_metrics_by_sequence(
-            view=_NoKeyframeView(),
+            view=_EmptyDetectionsView(),
             gt_field="gt",
             pred_fields=["pred"],
             metrics=[(_CapturingMetric, {})],
         )
 
-    assert len(failures) == 1
-    assert failures[0][0] == "seq-1"
-    assert "pred" in str(failures[0][1])
+    assert len(updates) == 1
+    gt_shape, pred_shape, seq = updates[0]
+    assert seq == "seq-1"
+    assert gt_shape[0] == 0
+    assert pred_shape[0] == 0
 
 
 def test_sequence_skipped_logs_all_pred_fields_when_one_missing():
-    """When one pred_field lacks keyframes, all pred_fields are logged as failed."""
-    failures = []
+    """When one pred_field is absent, every metric instance logs the failure."""
+    metrics_by_field = {}
 
     class _CapturingMetric:
         def __init__(self) -> None:
@@ -201,27 +203,32 @@ def test_sequence_skipped_logs_all_pred_fields_when_one_missing():
             raise AssertionError("should not be called")
 
         def log_failed_sequence(self, seq, _gt, _pred, **_kwargs: object):
-            failures.append(seq)
             self.failed_sequences[seq] = str(_kwargs.get("exc"))
 
-    class _PartialKeyframeView(_FakeVideoView):
-        def values(self, field):
-            if "pred_a.keyframe" in field:
-                return [True, False, True]
-            if "pred_b.keyframe" in field:
-                return [False, False, False]
-            return super().values(field)
-
     with _fo_patch():
-        utils.compute_all_metrics_by_sequence(
+        metrics_by_field = utils.compute_all_metrics_by_sequence(
             view=_PartialKeyframeView(),
             gt_field="gt",
             pred_fields=["pred_a", "pred_b"],
             metrics=[(_CapturingMetric, {})],
         )
 
-    assert len(failures) == 2
-    assert all(seq == "seq-1" for seq in failures)
+    for pf in ("pred_a", "pred_b"):
+        reason = metrics_by_field[pf]["_CapturingMetric"].failed_sequences["seq-1"]
+        assert "Field not found" in reason
+        assert "pred_b" in reason
+
+
+class _PartialKeyframeView(_FakeVideoView):
+    def has_frame_field(self, field):
+        return field != "pred_b"
+
+    def values(self, field):
+        if "pred_a.keyframe" in field:
+            return [True, False, True]
+        if "pred_b.keyframe" in field:
+            return [False, False, False]
+        return super().values(field)
 
 
 def test_results_to_df_formats_hota_and_tracking_outputs():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Empty prediction arrays from `prepare_data_for_det_metrics` were 1-D `(0,)` instead of MOT-shaped `(0, 10)`, causing `TrackingMetrics.update` to crash when a sequence had keyframe GT but no predictions. Cross-metric propagation then surfaced misleading "No ground truth and no predictions" on HOTA and other pred fields.

## Why?

The Cascais sequence (`Watchkeeper_2025_05_15_Cascais_ST3_2025_05_15_22_00_34`) has keyframes but no predictions for most models; one verification run also had GT without preds. After the empty-detection handling change, these sequences passed validation but failed at metric update time.

## How?

| Location | Change |
|---|---|
| `prepare_data_for_det_metrics` | Always return `reshape(-1, 10)` so empty sides are `(0, 10)` |
| `TrackingMetrics.update` | Normalize legacy 1-D empty arrays before column indexing |
| `HOTAMetrics._pool` | Use `(0, 10)` empty arrays for consistency |
| `compute_all_metrics_by_sequence` | Propagate the original failure reason instead of overwriting with a generic empty-data message |

## Testing

<!-- To be filled in manually. -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8732f8f-3852-472a-9a26-8020ac144a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8732f8f-3852-472a-9a26-8020ac144a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

