### PR TITLE
Add test for empty GT with non-empty predictions in TrackingMetrics

### DIFF
--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -28,7 +28,9 @@ class TrackingMetrics:
 
     def update(self, gt: np.ndarray, pred: np.ndarray, sequence_name: str) -> None:
         """Build a MOTAccumulator for *sequence_name* from (gt, pred) arrays."""
-        num_frames = max(gt[:, 0].max(), pred[:, 0].max()) + 1
+        gt_max_frame = gt[:, 0].max() if gt.size > 0 else 0
+        pred_max_frame = pred[:, 0].max() if pred.size > 0 else 0
+        num_frames = max(gt_max_frame, pred_max_frame) + 1
         acc = mm.MOTAccumulator(auto_id=True)
 
         for i in range(1, int(num_frames)):

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pytest
 
@@ -91,6 +93,55 @@ class TestNoPredictions:
     def test_false_positives(self):
         r = self.m.compute("seq")
         assert _scalar(r, "num_false_positives") == 1
+
+
+# ---------------------------------------------------------------------------
+# No ground truth
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingNoGT:
+    """All predictions, no ground truth — motmetrics counts every pred as FP.
+
+    With zero GT objects, recall is undefined (NaN) and MOTA divides by zero
+    (-inf). Precision is well-defined: TP / (TP + FP) = 0 / N = 0.
+    """
+
+    def setup_method(self):
+        gt = np.empty((0, 6))
+        pred = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 1, 1, 11, 11),
+        )
+        self.m = TrackingMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_false_positives(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_false_positives") == 2
+
+    def test_no_gt_objects(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_unique_objects") == 0
+
+    def test_no_misses(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_misses") == 0
+
+    def test_precision_is_zero(self):
+        # precision = TP / (TP + FP) = 0 / 2
+        r = self.m.compute("seq")
+        assert _scalar(r, "precision") == pytest.approx(0.0)
+
+    def test_recall_is_nan(self):
+        # recall = TP / num_objects = 0 / 0 → undefined
+        r = self.m.compute("seq")
+        assert math.isnan(_scalar(r, "recall"))
+
+    def test_mota_is_negative_inf(self):
+        # MOTA = 1 - FP / num_objects = 1 - 2/0
+        r = self.m.compute("seq")
+        assert _scalar(r, "mota") == float("-inf")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -144,6 +144,48 @@ class TestTrackingNoGT:
         assert _scalar(r, "mota") == float("-inf")
 
 
+class TestTrackingNoGTOverallPooling:
+    """Pool a perfect sequence with an empty-GT sequence.
+
+    motmetrics OVERALL recomputes ratio metrics from summed counts, so B's
+    per-sequence NaN recall does not poison the dataset-level score.
+    """
+
+    def setup_method(self):
+        gt_a = _array(_det(1, 1, 0, 0, 10, 10), _det(2, 1, 1, 1, 11, 11))
+        pred_a = gt_a.copy()
+        gt_b = np.empty((0, 6))
+        pred_b = _array(_det(1, 1, 0, 0, 10, 10), _det(2, 1, 1, 1, 11, 11))
+
+        self.m = TrackingMetrics()
+        self.m.update(gt_a, pred_a, "A")
+        self.m.update(gt_b, pred_b, "B")
+        self.r = self.m.compute(["A", "B"])
+
+    def test_empty_gt_sequence_recall_is_nan(self):
+        assert math.isnan(self.r["recall"]["B"])
+
+    def test_overall_precision(self):
+        # pooled: TP=2, FP=2 → 2 / (2 + 2)
+        assert self.r["precision"]["OVERALL"] == pytest.approx(0.5)
+
+    def test_overall_recall(self):
+        # pooled: TP=2, num_objects=2 → not NaN despite B's undefined recall
+        assert self.r["recall"]["OVERALL"] == pytest.approx(1.0)
+
+    def test_overall_mota(self):
+        # pooled: 1 - (misses + switches + FP) / num_objects = 1 - 2/2
+        assert self.r["mota"]["OVERALL"] == pytest.approx(0.0)
+
+    def test_overall_false_positives_summed(self):
+        assert self.r["num_false_positives"]["OVERALL"] == 2
+
+    def test_overall_mota_differs_from_per_sequence_mean(self):
+        # Naive mean of per-sequence MOTA (1.0, -inf) is not the MOT-standard pool.
+        per_seq_mean = np.mean([self.r["mota"]["A"], self.r["mota"]["B"]])
+        assert self.r["mota"]["OVERALL"] != pytest.approx(per_seq_mean)
+
+
 # ---------------------------------------------------------------------------
 # ID switch
 # ---------------------------------------------------------------------------

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -95,6 +95,39 @@ class TestNoPredictions:
         assert _scalar(r, "num_false_positives") == 1
 
 
+class TestTrackingEmptyPred:
+    """GT present, empty pred array → all GT objects missed."""
+
+    def setup_method(self):
+        gt = _array(
+            _det(1, 1, 0, 0, 10, 10),
+            _det(2, 1, 0, 0, 10, 10),
+            _det(3, 1, 0, 0, 10, 10),
+        )
+        pred = np.empty((0, 6))
+        self.m = TrackingMetrics()
+        self.m.update(gt, pred, "seq")
+
+    def test_misses(self):
+        r = self.m.compute("seq")
+        assert _scalar(r, "num_misses") == 3
+
+    def test_recall_is_zero(self):
+        # recall = TP / num_objects = 0 / 3
+        r = self.m.compute("seq")
+        assert _scalar(r, "recall") == pytest.approx(0.0)
+
+    def test_mota_is_zero(self):
+        # Three misses, no false positives or switches over three GT appearances.
+        r = self.m.compute("seq")
+        assert _scalar(r, "mota") == pytest.approx(0.0)
+
+    def test_precision_is_nan(self):
+        # precision = TP / (TP + FP) = 0 / 0 → undefined
+        r = self.m.compute("seq")
+        assert math.isnan(_scalar(r, "precision"))
+
+
 # ---------------------------------------------------------------------------
 # No ground truth
 # ---------------------------------------------------------------------------

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -174,7 +174,7 @@ class TestTrackingNoGTOverallPooling:
         assert self.r["recall"]["OVERALL"] == pytest.approx(1.0)
 
     def test_overall_mota(self):
-        # pooled: 1 - (misses + switches + FP) / num_objects = 1 - 2/2
+        # Two pooled false positives against two GT object appearances.
         assert self.r["mota"]["OVERALL"] == pytest.approx(0.0)
 
     def test_overall_false_positives_summed(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add `TestTrackingNoGT` to pin how motmetrics behaves when ground truth is empty but predictions are not. Also fix `TrackingMetrics.update()` so it no longer crashes on empty GT arrays (matching the guard already used in HOTA and `user_friendly`).

## Why

Empty GT with non-empty predictions is a realistic edge case (e.g. a sequence with no annotated objects but model detections). motmetrics handles it: every prediction is a false positive, precision is 0, and recall is undefined. `TrackingMetrics.update()` previously raised `ValueError` on `gt[:, 0].max()`, so the pipeline logged the sequence as failed (`"No ground truth"`) instead of computing those metrics.

## How

- Guard `num_frames` computation in `track.py` when `gt` or `pred` is empty (`size == 0` → frame max of 0).
- Add `TestTrackingNoGT` mirroring `TestHOTANoGT` in `test_hota.py`, with hand-computed assertions:
  - `num_false_positives == 2`
  - `precision == 0`
  - `recall` is NaN
  - `mota == -inf` (divide-by-zero with zero GT objects)

## Testing

```bash
uv run pytest tests/tracking/test_tracking_metrics.py::TestTrackingNoGT -v
uv run pytest tests/tracking/test_tracking_metrics.py -v
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b31d1d71-6b09-407c-93c6-2b474c46d112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b31d1d71-6b09-407c-93c6-2b474c46d112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking metric calculations to safely handle empty ground-truth or prediction inputs without errors.
  * Metrics now produce sensible outputs for empty ground truth, including correct false-positive counting and defined/undefined-style recall behavior as appropriate.

* **Tests**
  * Added coverage for empty-input edge cases (no predictions, no ground truth) and verified per-sequence and pooled overall metric behavior across multiple sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->