### PR TITLE
SEA-1130 fix(tracking): convert xyxy boxes to xywh before motmetrics iou_matrix

### DIFF
--- a/seametrics/tracking/track.py
+++ b/seametrics/tracking/track.py
@@ -5,6 +5,7 @@ from collections import Counter
 import motmetrics as mm
 import numpy as np
 
+from ._box_utils import box_convert
 from .constants import COUNT_METRICS, RATIO_METRICS
 from .utils import failed_sequence_reason
 
@@ -26,7 +27,10 @@ class TrackingMetrics:
             setattr(self, key, value)
 
     def update(self, gt: np.ndarray, pred: np.ndarray, sequence_name: str) -> None:
-        """Build a MOTAccumulator for *sequence_name* from (gt, pred) arrays."""
+        """Build a MOTAccumulator for *sequence_name* from (gt, pred) arrays.
+
+        Rows are ``[frame, id, x1, y1, x2, y2, …]`` with boxes in xyxy format.
+        """
         gt_max_frame = gt[:, 0].max() if gt.size > 0 else 0
         pred_max_frame = pred[:, 0].max() if pred.size > 0 else 0
         num_frames = max(gt_max_frame, pred_max_frame) + 1
@@ -36,8 +40,11 @@ class TrackingMetrics:
             gt_dets = gt[gt[:, 0] == i, 1:6]
             pred_dets = pred[pred[:, 0] == i, 1:6]
 
+            # motmetrics expects xywh boxes; our public contract is xyxy.
             dist_matrix = mm.distances.iou_matrix(
-                gt_dets[:, 1:], pred_dets[:, 1:], max_iou=self.max_iou
+                box_convert(gt_dets[:, 1:], in_fmt="xyxy", out_fmt="xywh"),
+                box_convert(pred_dets[:, 1:], in_fmt="xyxy", out_fmt="xywh"),
+                max_iou=self.max_iou,
             )
             acc.update(
                 gt_dets[:, 0].astype("int").tolist(),

--- a/tests/tracking/test_tracking_metrics.py
+++ b/tests/tracking/test_tracking_metrics.py
@@ -220,6 +220,64 @@ class TestTrackingNoGTOverallPooling:
 
 
 # ---------------------------------------------------------------------------
+# Box-format regression (xyxy contract)
+# ---------------------------------------------------------------------------
+
+
+class TestBoxFormatRegression:
+    """Boxes are xyxy; update() must convert to xywh for motmetrics.
+
+    Feeding xyxy straight to ``motmetrics.distances.iou_matrix`` (which reads
+    (x, y, w, h)) turns x2/y2 into phantom widths/heights, so disjoint boxes
+    far from the origin can overlap almost entirely and get matched. The
+    origin-anchored, GT==pred boxes used elsewhere in this file are degenerate
+    under that misreading, which is why these cases live off-origin.
+    """
+
+    def test_disjoint_boxes_do_not_match(self):
+        # Two 10x10 boxes with a 5 px gap: true IoU = 0. Misread as xywh they
+        # become [2400,400,4810,810] and [2415,400,4840,810] (IoU ~0.98).
+        gt = _array(_det(1, 1, 2400, 400, 2410, 410))
+        pred = _array(_det(1, 7, 2415, 400, 2425, 410))
+        m = TrackingMetrics()
+        m.update(gt, pred, "seq")
+        r = m.compute("seq")
+        assert _scalar(r, "recall") == pytest.approx(0.0)
+        assert _scalar(r, "num_false_positives") == 1
+        assert _scalar(r, "num_misses") == 1
+
+    def test_far_apart_boxes_do_not_match(self):
+        # Two 10x10 boxes ~800 px apart.
+        gt = _array(_det(1, 1, 2400, 400, 2410, 410))
+        pred = _array(_det(1, 7, 3200, 450, 3210, 460))
+        m = TrackingMetrics()
+        m.update(gt, pred, "seq")
+        r = m.compute("seq")
+        assert _scalar(r, "recall") == pytest.approx(0.0)
+        assert _scalar(r, "num_false_positives") == 1
+        assert _scalar(r, "num_misses") == 1
+
+    def test_partial_overlap_iou_reaches_motp(self):
+        # 20x20 boxes shifted 5 px: IoU = (15*20) / (400+400-300) = 0.6.
+        # motmetrics MOTP is the mean matched distance, 1 - IoU = 0.4.
+        gt = _array(_det(1, 1, 2400, 400, 2420, 420))
+        pred = _array(_det(1, 1, 2405, 400, 2425, 420))
+        m = TrackingMetrics()
+        m.update(gt, pred, "seq")
+        r = m.compute("seq")
+        assert _scalar(r, "recall") == pytest.approx(1.0)
+        assert _scalar(r, "motp") == pytest.approx(0.4)
+
+    def test_identical_off_origin_boxes_match(self):
+        gt = _array(_det(1, 1, 2400, 400, 2410, 410))
+        m = TrackingMetrics()
+        m.update(gt, gt.copy(), "seq")
+        r = m.compute("seq")
+        assert _scalar(r, "mota") == pytest.approx(1.0)
+        assert _scalar(r, "motp") == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
 # ID switch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What?

`TrackingMetrics.update()` was feeding xyxy-format boxes directly into `motmetrics`' IoU matcher, which expects `(x, y, w, h)` — so `x2`/`y2` were silently read as width/height. Boxes are now converted to xywh right before matching, so IoU (and every metric derived from it) reflects the real overlap between GT and predicted boxes.

## Why?

`seametrics` results feed model-selection and production decisions, so a silently wrong metric is worse than a crash. The format mismatch let far-apart or fully disjoint GT/pred boxes register as matches, inflating recall/precision/MOTA and hiding real tracking failures — existing tests didn't catch it because they only used origin-anchored or identical GT/pred boxes, which are degenerate under the bug.

## How?

| Input boxes (xyxy) | True IoU | Before fix | After fix |
|---|---|---|---|
| GT `[2400,400,2410,410]`, Pred `[2415,400,2425,410]` (10×10 boxes, 5px gap) | 0 | recall 1.0, 0 FP | recall 0.0, 1 FP |

- Convert the sliced boxes xyxy→xywh via the existing `_box_utils.box_convert` helper immediately before the `motmetrics.distances.iou_matrix` call, keeping the public xyxy contract (`[frame, id, x1, y1, x2, y2, …]`) unchanged for callers.
- `HOTAMetrics` already computes IoU natively in xyxy, so it's unaffected and left untouched.
- Added `TestBoxFormatRegression` with off-origin cases (disjoint boxes, far-apart boxes, a hand-computed partial-overlap MOTP check, and an identical-boxes positive control) that only pass with the correct conversion.

## Testing

<!-- To be filled in manually. -->
